### PR TITLE
Make sure a compatible version of bundler is installed before we run bundle install

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+gem install bundler --version '~> 1.11'
 bundle install
 
 # Do any other automated setup that you need to do here


### PR DESCRIPTION
Project needs bundler version 1.11.* or newer (1.11.2 in fact)