### PR TITLE
[gemspec] require ruby >= 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: ruby
 cache: bundler
 before_install:
-- gem install bundler -v 1.11.2
+- gem install bundler -v 1.15.1
 rvm:
-- 2.3.0
-- 2.2.4
-- 2.1.8
-- jruby-9.0.5.0
-- rbx-3.19
-matrix:
-  allow_failures:
-  - rvm: rbx-3.19
+- 2.4.1
+- 2.3.1
+- 2.2.5
+- 2.1.9
 script:
 - rake install
 - 3scale help

--- a/3scale_toolbox.gemspec
+++ b/3scale_toolbox.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.required_ruby_version = '>= 2.1'
 
   spec.add_dependency '3scale-api', '~> 0.1.2'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
 ### Added
+
 ### Changed
+- Require Ruby >= 2.1 in the gemspec
+
 ### Fixed
 
 ## [0.2.2] - 2016-04-21


### PR DESCRIPTION
closes #24
closes #29

this drops support for JRuby because of https://github.com/rubygems/rubygems/issues/1263