### PR TITLE
Support backend_version

### DIFF
--- a/exe/3scale-copy
+++ b/exe/3scale-copy
@@ -60,6 +60,7 @@ def copy_service_params(original, system_name)
   {
     name:        original['name'],
     system_name: system_name,
+    backend_version: original['backend_version'],
     end_user_registration_required: original['end_user_registration_required']
   }.reject { |key, value| !value }
 end


### PR DESCRIPTION
I added "backend_version" to 3scale-copy.
We will be able to copy not only "API Key (user_key)" services but also "App_ID and App_Key Pair", "OAuth 2.0" and "OpenID Connect" services.
However, currently we cannot copy "OpenID Connect" services because of "https://issues.jboss.org/browse/THREESCALE-571".