### PR TITLE
Bundle Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/3scale_toolbox.gemspec
+++ b/3scale_toolbox.gemspec
@@ -15,6 +15,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/3scale/3scale_toolbox'
 
   spec.files         = Dir['{lib}/**/*.rb'] + %w[README.md] + Dir['exe/*']
+  # Gemfile* and gemspec are included here to support
+  # running Bundler at gem install time.
+  spec.files         << 'Gemfile'
+  spec.files         << 'Gemfile.lock'
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,47 @@
+PATH
+  remote: .
+  specs:
+    3scale_toolbox (0.4.0)
+      3scale-api (~> 0.1)
+      cri (~> 2.10)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    3scale-api (0.1.5)
+    coderay (1.1.2)
+    colored (1.2)
+    cri (2.15.1)
+      colored (~> 1.2)
+    diff-lcs (1.3)
+    method_source (0.9.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    rake (10.5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  3scale_toolbox!
+  bundler (~> 1.11)
+  pry
+  rake (~> 10.0)
+  rspec (~> 3.7)
+
+BUNDLED WITH
+   1.13.7


### PR DESCRIPTION
Bundle Gemfile and Gemfile.lock to gem package for packaging as RPM for RHEL.

Add Gemfile.lock because this is a tool, not a library.