### PR TITLE
3scale_toolbox.gemspec: remove bundler devel dep

### DIFF
--- a/3scale_toolbox.gemspec
+++ b/3scale_toolbox.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.required_ruby_version = '>= 2.1'


### PR DESCRIPTION
[Ruby 2.3 by Software Collections](https://www.softwarecollections.org/en/scls/rhscl/rh-ruby23/) includes bundler which version (1.10) conflicts with required bundler version (1.11) right now. 

http://mirror.centos.org/centos/7/sclo/x86_64/rh/rh-ruby23/

Removing this requirement to enable RPM packaging for RHEL 7 with Ruby 2.3 enabled by Software Collections