### PR TITLE
update service: only include system_name when specified in options

### DIFF
--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,0 +1,30 @@
+RSpec.shared_examples 'target service params' do
+  include_context :source_service_data
+
+  it 'all expected params are copied' do
+    target_service_obj = subject.target_service_params(source_service_obj)
+    expect(target_service_obj).to include(*target_service_params)
+  end
+
+  it 'extra params are not copied' do
+    extra_params = {
+      'some_weird_param' => 'value0',
+      'some_other_weird_param' => 'value1'
+    }
+    target_service_obj = subject.target_service_params(
+      source_service_obj.merge(extra_params)
+    )
+    expect(target_service_obj).to include(*target_service_params)
+    expect(target_service_obj).not_to include(*extra_params)
+  end
+
+  it 'missing params are not copied' do
+    missing_params = %w[description backend_version]
+    missing_params.each do |key|
+      source_service_obj.delete(key)
+    end
+    target_service_obj = subject.target_service_params(source_service_obj)
+    expect(target_service_obj).to include(*(target_service_params - missing_params))
+    expect(target_service_obj).not_to include(*missing_params)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@
 # it.
 
 require_relative 'shared_contexts'
+require_relative 'shared_examples'
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/spec/unit/update_service_spec.rb
+++ b/spec/unit/update_service_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe ThreeScaleToolbox::Commands::UpdateCommand::UpdateServiceSubcomma
                                                                     'source_service_id',
                                                                     'destination_id',
                                                                     'target_service_id',
-                                                                    true).and_return(updater)
+                                                                    true,
+                                                                    nil).and_return(updater)
       opts = {
         source: 'source_id',
         destination: 'destination_id',
@@ -27,7 +28,8 @@ RSpec.describe ThreeScaleToolbox::Commands::UpdateCommand::UpdateServiceSubcomma
                                                                     'source_service_id',
                                                                     'destination_id',
                                                                     'target_service_id',
-                                                                    false).and_return(updater)
+                                                                    false,
+                                                                    nil).and_return(updater)
       opts = {
         source: 'source_id',
         destination: 'destination_id'
@@ -38,42 +40,37 @@ RSpec.describe ThreeScaleToolbox::Commands::UpdateCommand::UpdateServiceSubcomma
 end
 
 RSpec.describe ThreeScaleToolbox::Commands::UpdateCommand::UpdateServiceSubcommand::ServiceUpdater do
-  include_context :source_service_data
-
-  subject do
-    described_class.new(
-      'https://provider_key_a@example.com',
-      'source_service_id',
-      'https://provider_key_a@example.com',
-      'destination_service_id',
-      true
-    )
-  end
-
   context '#target_service_params' do
-    it 'all expected params are copied' do
-      target_service_obj = subject.target_service_params(source_service_obj)
-      expect(target_service_obj).to include(*source_service_params)
-    end
-    it 'extra params are not copied' do
-      extra_params = {
-        'some_weird_param' => 'value0',
-        'some_other_weird_param' => 'value1'
-      }
-      target_service_obj = subject.target_service_params(
-        source_service_obj.merge(extra_params)
-      )
-      expect(target_service_obj).to include(*source_service_params)
-      expect(target_service_obj).not_to include(*extra_params)
-    end
-    it 'missing params are not copied' do
-      missing_params = %w[description backend_version]
-      missing_params.each do |key|
-        source_service_obj.delete(key)
+    context 'with target system name' do
+      subject do
+        described_class.new(
+          'https://provider_key_a@example.com',
+          'source_service_id',
+          'https://provider_key_a@example.com',
+          'destination_service_id',
+          true,
+          'some_target_system_name'
+        )
       end
-      target_service_obj = subject.target_service_params(source_service_obj)
-      expect(target_service_obj).to include(*source_service_obj.keys)
-      expect(target_service_obj).not_to include(*missing_params)
+      let(:target_service_params) { source_service_params }
+      include_examples 'target service params'
+    end
+
+    context 'without target system name' do
+      subject do
+        described_class.new(
+          'https://provider_key_a@example.com',
+          'source_service_id',
+          'https://provider_key_a@example.com',
+          'destination_service_id',
+          true,
+          nil
+        )
+      end
+      let(:target_service_params) do
+        source_service_params.reject { |k| k == 'system_name' }
+      end
+      include_examples 'target service params'
     end
   end
 end


### PR DESCRIPTION
When updating service from source to destination, source `system_name` is being sent to update destination `system_name`. This is a problem when updating services within the same tenant, since you would get the  following error from API:
```json
{"system_name": ["has already been taken"]}
```
The fix is: do not try to overwrite system name, unless specified using command's new optional argument with option `-t, --target_system_name`
