### PR TITLE
Fix option parsing on update service command

### DIFF
--- a/lib/3scale_toolbox/commands/update_command/update_service.rb
+++ b/lib/3scale_toolbox/commands/update_command/update_service.rb
@@ -229,7 +229,7 @@ module ThreeScaleToolbox
           destination = fetch_required_option(:destination)
           source_service_id = arguments[:src_service_id]
           target_service_id = arguments[:dst_service_id]
-          system_name = opts[:target_system_name]
+          system_name = options[:target_system_name]
           updater = ServiceUpdater.new(source, source_service_id, destination, target_service_id, system_name, verify_ssl)
 
           force_update = options[:force]


### PR DESCRIPTION
Previous PR merge operation caused broken update service command.

Testing would avoid this issue. 