### PR TITLE
Global error handler

### DIFF
--- a/exe/3scale
+++ b/exe/3scale
@@ -4,4 +4,4 @@ require '3scale_toolbox'
 
 args = ARGV.clone
 
-exit(ThreeScaleToolbox::CLI.run(args) ? 1 : 0)
+exit(ThreeScaleToolbox::CLI.run(args))

--- a/lib/3scale_toolbox/cli.rb
+++ b/lib/3scale_toolbox/cli.rb
@@ -33,10 +33,11 @@ module ThreeScaleToolbox::CLI
 
   def self.run(args)
     install_signal_handlers
-    ErrorHandler.error_watchdog do
+    err = ErrorHandler.error_watchdog do
       load_builtin_commands
       ThreeScaleToolbox.load_plugins
       root_command.build_command.run args
     end
+    err.nil? ? 0 : 1
   end
 end

--- a/lib/3scale_toolbox/cli/error_handler.rb
+++ b/lib/3scale_toolbox/cli/error_handler.rb
@@ -9,15 +9,13 @@ module ThreeScaleToolbox
 
       # Catches errors and prints nice diagnostic messages
       def error_watchdog
-        error = false
-        begin
-          # Run
-          yield
-        rescue StandardError, ScriptError => e
-          handle_error e
-          error = true
-        end
-        error
+        # Run
+        yield
+      rescue StandardError, ScriptError => e
+        handle_error e
+        e
+      else
+        nil
       end
 
       private

--- a/spec/unit/error_handler_spec.rb
+++ b/spec/unit/error_handler_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe ThreeScaleToolbox::CLI::ErrorHandler do
         end
       end
 
-      it 'returns true' do
+      it 'returns error' do
         expect(
           subject.error_watchdog { raise_toolbox_error }
-        ).to be_truthy
+        ).to be
       end
     end
 
@@ -39,16 +39,16 @@ RSpec.describe ThreeScaleToolbox::CLI::ErrorHandler do
         end
       end
 
-      it 'returns true' do
+      it 'returns error' do
         expect(
           subject.error_watchdog { raise_runtime_error }
-        ).to be_truthy
+        ).to be
       end
     end
 
     context 'Does not raise error' do
       it 'returns true' do
-        expect(subject.error_watchdog {}).to be_falsey
+        expect(subject.error_watchdog {}).to be_nil
       end
     end
   end


### PR DESCRIPTION
Main error handler for all commands

- print just error when error type is expected or generated in a controlled manner
- print verbose information when unexpected error happen. In addition to stack trace dump, `crash.log` is created with app version, system information, installed gems and load paths