### PR TITLE
License finder

### DIFF
--- a/.dependency_decisions.yml
+++ b/.dependency_decisions.yml
@@ -1,0 +1,68 @@
+---
+- - :whitelist
+  - MIT
+  - :who: 3scale Engineering
+    :why: 
+    :versions: []
+    :when: 2016-08-16 09:25:15.635515271 Z
+- - :whitelist
+  - Apache 2.0
+  - :who: 3scale Engineering
+    :why: 
+    :versions: []
+    :when: 2016-08-16 09:26:31.814319646 Z
+- - :whitelist
+  - MIT-LICENSE
+  - :who: 3scale Engineering
+    :why: It's the same as MIT
+    :versions: []
+    :when: 2016-08-16 09:27:49.047135842 Z
+- - :license
+  - rake
+  - MIT
+  - :who: 3scale Engineering
+    :why: Rake uses MIT but it's not automatically detected
+    :versions: []
+    :when: 2016-08-18 15:16:38.712225384 Z
+- - :approve
+  - 3scale_backend
+  - :who: 3scale Engineering
+    :why: It's this project.
+    :versions: []
+    :when: 2016-08-18 15:18:39.314149125 Z
+- - :whitelist
+  - BSD
+  - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
+    :why: 
+    :versions: []
+    :when: 2016-11-23 11:02:51.564502000 Z
+- - :whitelist
+  - New BSD
+  - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
+    :why: 
+    :versions: []
+    :when: 2016-11-23 11:03:04.247155000 Z
+- - :whitelist
+  - ruby
+  - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
+    :why: 
+    :versions: []
+    :when: 2016-11-23 11:03:15.526798000 Z
+- - :whitelist
+  - Simplified BSD
+  - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
+    :why: 
+    :versions: []
+    :when: 2016-11-23 11:03:33.341497000 Z
+- - :whitelist
+  - LGPLv2+
+  - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
+    :why: 
+    :versions: []
+    :when: 2016-11-23 11:04:13.584885000 Z
+- - :whitelist
+  - 2-clause BSDL
+  - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
+    :why: 
+    :versions: []
+    :when: 2016-11-23 11:04:37.776089000 Z

--- a/.dependency_decisions.yml
+++ b/.dependency_decisions.yml
@@ -63,6 +63,6 @@
 - - :approve
   - colored
   - :who: 
-    :why: 
+    :why: MIT License https://github.com/defunkt/colored/blob/master/LICENSE
     :versions: []
     :when: 2018-12-06 16:05:25.674247558 Z

--- a/.dependency_decisions.yml
+++ b/.dependency_decisions.yml
@@ -24,12 +24,6 @@
     :why: Rake uses MIT but it's not automatically detected
     :versions: []
     :when: 2016-08-18 15:16:38.712225384 Z
-- - :approve
-  - 3scale_backend
-  - :who: 3scale Engineering
-    :why: It's this project.
-    :versions: []
-    :when: 2016-08-18 15:18:39.314149125 Z
 - - :whitelist
   - BSD
   - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
@@ -66,3 +60,9 @@
     :why: 
     :versions: []
     :when: 2016-11-23 11:04:37.776089000 Z
+- - :approve
+  - colored
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2018-12-06 16:05:25.674247558 Z

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache: bundler
 before_install:
 - gem install bundler -v 1.15.1
 rvm:
-- 2.5.1
-- 2.4.1
-- 2.3.1
+- 2.5.3
+- 2.4.5
+- 2.3.8
 script:
   - bundle exec rake license_finder:check
   - bundle exec rake spec:all

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 - 2.4.1
 - 2.3.1
 script:
+  - bundle exec rake license_finder:check
   - bundle exec rake spec:all
   - bundle exec 3scale help
   - bundle exec 3scale help copy

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  gem 'license_finder', '~> 5.5'
   gem 'pry'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -17,4 +17,22 @@ rescue LoadError
   warn 'RSpec is not installed!'
 end
 
+namespace :license_finder do
+  DECISION_FILE = "#{File.dirname(__FILE__)}/.dependency_decisions.yml".freeze
+
+  desc 'Check license compliance of dependencies'
+  task :check do
+    STDOUT.puts "Checking license compliance\n"
+    unless system("license_finder --decisions-file=#{DECISION_FILE}")
+      STDERR.puts "\n*** License compliance test failed  ***\n"
+      exit 1
+    end
+  end
+
+  desc 'Generate an CSV report for licenses'
+  task :report do
+    system("license_finder report --decisions-file=#{DECISION_FILE} --format=csv")
+  end
+end
+
 task default: 'spec:all'


### PR DESCRIPTION
Two rake tasks added:
* License finder check `license_finder:check`
* License finder report  `license_finder:report`

License finder check added on CI

License whitelist and approval list on `/.dependency_decisions.yml`

Note: Only CSV format report