### PR TITLE
import openapi: fix when missing operation id in spec

### DIFF
--- a/lib/3scale_toolbox/commands/import_command/openapi/method.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/method.rb
@@ -12,11 +12,15 @@ module ThreeScaleToolbox
           end
 
           def friendly_name
-            operation[:operationId]
+            operation[:operationId] || operation_id
           end
 
           def system_name
             friendly_name.downcase
+          end
+
+          def operation_id
+            "#{operation[:verb]}#{operation[:path].gsub(/[^\w]/, '')}"
           end
         end
       end

--- a/spec/unit/commands/import_command/openapi/method_spec.rb
+++ b/spec/unit/commands/import_command/openapi/method_spec.rb
@@ -22,4 +22,18 @@ RSpec.describe 'OpenAPI Method' do
       is_expected.to include('system_name' => operationId.downcase)
     end
   end
+
+  context 'operation id not available' do
+    let(:operation) { { verb: 'get', path: '/pet/{petId}' } }
+
+    subject { OpenAPIMethodClass.new(operation).method }
+
+    it 'contains "friendly_name"' do
+      is_expected.to include('friendly_name' => 'getpetpetId')
+    end
+
+    it 'contains "system_name"' do
+      is_expected.to include('system_name' => 'getpetpetid')
+    end
+  end
 end


### PR DESCRIPTION
in OAS 2.0, when there is no `operation_id` attribute, i.e.

```json
....
"paths": {
    "/products": {
      "get": {
        "summary": "Product Types",
        "description": "The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.",
        "parameters": [
          {
            "name": "latitude",
            "in": "query",
            "description": "Latitude component of location.",
            "required": true,
            "type": "number",
            "format": "double"
          },
          {
            "name": "longitude",
            "in": "query",
            "description": "Longitude component of location.",
            "required": true,
            "type": "number",
            "format": "double"
          }
        ],
        "tags": [
          "Products"
        ],
        "responses": {
          "200": {
            "description": "An array of products",
            "schema": {
              "type": "array",
              "items": {
                "$ref": "#/definitions/Product"
              }
            }
          },
          "default": {
            "description": "Unexpected error",
            "schema": {
              "$ref": "#/definitions/Error"
            }
          }
        }
      }
    }
....
```

method names are computed:

```ruby
"#{operation[:verb]}#{operation[:path].tr('/{}', '')}"
```