### PR TITLE
Import oas include activedocs

### DIFF
--- a/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
@@ -1,0 +1,52 @@
+module ThreeScaleToolbox
+  module Commands
+    module ImportCommand
+      module OpenAPI
+        class CreateActiveDocsStep
+          include Step
+
+          def call
+            active_doc = {
+              name: api_spec.title,
+              system_name: activedocs_system_name,
+              service_id: service.id,
+              body: resource.to_json,
+              description: api_spec.description
+            }
+
+            res = threescale_client.create_activedocs(active_doc)
+            # Make operation indempotent
+            if (errors = res['errors'])
+              raise ThreeScaleToolbox::Error, "ActiveDocs has not been created. #{errors}" \
+                unless system_name_already_taken_error? errors
+
+              # if activedocs system_name exists, ignore error, update activedocs
+              puts 'Activedocs exists, update!'
+              update_res = threescale_client.update_activedocs(find_activedocs_id, active_doc)
+              raise ThreeScaleToolbox::Error, "ActiveDocs has not been updated. #{update_res['errors']}" unless update_res['errors'].nil?
+            end
+          end
+
+          private
+
+          def activedocs_system_name
+            @activedocs_system_name ||= service.show_service['system_name']
+          end
+
+          def find_activedocs_id
+            activedocs = get_current_service_activedocs
+            raise ThreeScaleToolbox::Error, "Could not find activedocs with system_name: #{activedocs_system_name}" if activedocs.empty?
+
+            activedocs.dig(0, 'id')
+          end
+
+          def get_current_service_activedocs
+            threescale_client.list_activedocs.select do |activedoc|
+              activedoc['system_name'] == activedocs_system_name
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/import_command/openapi/create_method_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_method_step.rb
@@ -12,13 +12,11 @@ module ThreeScaleToolbox
               metric_id = res['id']
               # if method system_name exists, ignore error and get metric_id
               # Make operation indempotent
-              unless res['errors'].nil?
-                if !res['errors']['system_name'].nil? \
-                  && res['errors']['system_name'][0] =~ /has already been taken/
-                  metric_id = method_id_by_system_name[op.method['system_name']]
-                else
-                  raise Error, "Metohd has not been saved. Errors: #{res['errors']}"
-                end
+              if (errors = res['errors'])
+                raise Error, "Metohd has not been saved. #{errors}" \
+                  unless system_name_already_taken_error? errors
+
+                metric_id = method_id_by_system_name[op.method['system_name']]
               end
 
               op.set(:metric_id, metric_id)

--- a/lib/3scale_toolbox/commands/import_command/openapi/step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/step.rb
@@ -38,6 +38,14 @@ module ThreeScaleToolbox
             # could be nil
             context[:target_system_name]
           end
+
+          def resource
+            context[:api_spec_resource]
+          end
+
+          def system_name_already_taken_error?(error)
+            Array(Hash(error)['system_name']).any? { |msg| msg.match(/has already been taken/) }
+          end
         end
       end
     end

--- a/lib/3scale_toolbox/entities/service.rb
+++ b/lib/3scale_toolbox/entities/service.rb
@@ -116,6 +116,14 @@ module ThreeScaleToolbox
       def update_policies(params)
         remote.update_policies(id, params)
       end
+
+      def list_activedocs
+        remote.list_activedocs.select do |activedoc|
+          # service_id is optional attr. It would return nil and would not match
+          # activedocs endpoints return service_id as integers
+          activedoc['service_id'] == id.to_i
+        end
+      end
     end
   end
 end

--- a/spec/resources/petstore.yaml
+++ b/spec/resources/petstore.yaml
@@ -1,77 +1,262 @@
----
-swagger: "2.0"
+swagger: '2.0'
 info:
-  description: "This is a sample server Petstore server"
-  version: "1.0.0"
-  title: "Pet Store"
-host: "petstore.swagger.io"
-basePath: "/v2"
+  description: >-
+    This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+host: petstore.swagger.io
+basePath: /v2
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: 'http://swagger.io'
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+schemes:
+  - https
+  - http
 paths:
   /pet:
     post:
-      summary: "Add a new pet to the store"
-      description: ""
-      operationId: "addPet"
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
       consumes:
-      - "application/json"
-      - "application/xml"
+        - application/json
+        - application/xml
       produces:
-      - "application/xml"
-      - "application/json"
+        - application/xml
+        - application/json
       parameters:
-      - in: "body"
-        name: "body"
-        description: "Pet object that needs to be added to the store"
-        required: true
+        - in: body
+          name: body
+          description: Pet object that needs to be added to the store
+          required: true
+          schema:
+            $ref: '#/definitions/Pet'
       responses:
-        405:
-          description: "Invalid input"
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
     put:
-      summary: "Update an existing pet"
-      description: ""
-      operationId: "updatePet"
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
       consumes:
-      - "application/json"
-      - "application/xml"
+        - application/json
+        - application/xml
       produces:
-      - "application/xml"
-      - "application/json"
+        - application/xml
+        - application/json
       parameters:
-      - in: "body"
-        name: "body"
-        description: "Pet object that needs to be added to the store"
-        required: true
+        - in: body
+          name: body
+          description: Pet object that needs to be added to the store
+          required: true
+          schema:
+            $ref: '#/definitions/Pet'
       responses:
-        400:
-          description: "Invalid ID supplied"
-        404:
-          description: "Pet not found"
-        405:
-          description: "Validation exception"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
   /pet/findByStatus:
     get:
-      summary: "Finds Pets by status"
-      description: "Multiple status values can be provided with comma separated strings"
-      operationId: "findPetsByStatus"
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
       produces:
-      - "application/xml"
-      - "application/json"
+        - application/xml
+        - application/json
       parameters:
-      - name: "status"
-        in: "query"
-        description: "Status values that need to be considered for filter"
-        required: true
-        type: "array"
-        items:
-          type: "string"
-          enum:
-          - "available"
-          - "pending"
-          - "sold"
-          default: "available"
-        collectionFormat: "multi"
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          type: array
+          items:
+            type: string
+            enum:
+              - available
+              - pending
+              - sold
+            default: available
+          collectionFormat: multi
       responses:
-        200:
-          description: "successful operation"
-        400:
-          description: "Invalid status value"
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+securityDefinitions:
+  petstore_auth:
+    type: oauth2
+    authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+    flow: implicit
+    scopes:
+      'write:pets': modify pets in your account
+      'read:pets': read your pets
+  api_key:
+    type: apiKey
+    name: api_key
+    in: header
+definitions:
+  Order:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      petId:
+        type: integer
+        format: int64
+      quantity:
+        type: integer
+        format: int32
+      shipDate:
+        type: string
+        format: date-time
+      status:
+        type: string
+        description: Order Status
+        enum:
+          - placed
+          - approved
+          - delivered
+      complete:
+        type: boolean
+        default: false
+    xml:
+      name: Order
+  User:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      username:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      email:
+        type: string
+      password:
+        type: string
+      phone:
+        type: string
+      userStatus:
+        type: integer
+        format: int32
+        description: User Status
+    xml:
+      name: User
+  Category:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+    xml:
+      name: Category
+  Tag:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+    xml:
+      name: Tag
+  Pet:
+    type: object
+    required:
+      - name
+      - photoUrls
+    properties:
+      id:
+        type: integer
+        format: int64
+      category:
+        $ref: '#/definitions/Category'
+      name:
+        type: string
+        example: doggie
+      photoUrls:
+        type: array
+        xml:
+          name: photoUrl
+          wrapped: true
+        items:
+          type: string
+      tags:
+        type: array
+        xml:
+          name: tag
+          wrapped: true
+        items:
+          $ref: '#/definitions/Tag'
+      status:
+        type: string
+        description: pet status in the store
+        enum:
+          - available
+          - pending
+          - sold
+    xml:
+      name: Pet
+  ApiResponse:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      type:
+        type: string
+      message:
+        type: string
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'

--- a/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActiveDocsStep do
+  let(:service) { double('service') }
+  let(:api_spec_resource) { double('api_spec_resource') }
+  let(:api_spec) { double('api_spec') }
+  let(:service) { double('service') }
+  let(:threescale_client) { double('threescale_client') }
+  let(:openapi_context) do
+    {
+      api_spec_resource: api_spec_resource,
+      target: service,
+      api_spec: api_spec,
+      threescale_client: threescale_client
+    }
+  end
+  let(:title) { 'Some Title' }
+  let(:description) { 'Some Description' }
+  let(:oas_body) { '{}' }
+  let(:service_id) { 1 }
+  let(:service_system_name) { 'some_system_name' }
+  let(:activedocs_list) do
+    [
+      { 'id' => 1, 'system_name' => 'one' },
+      { 'id' => 2, 'system_name' => service_system_name },
+      { 'id' => 3, 'system_name' => 'other' }
+    ]
+  end
+  let(:service_attrs) { { 'id' => service_id, 'system_name' => service_system_name } }
+
+  subject { described_class.new(openapi_context) }
+
+  context '#call' do
+    before :each do
+      allow(api_spec).to receive(:title).and_return(title)
+      allow(api_spec).to receive(:description).and_return(description)
+      allow(service).to receive(:id).and_return(service_id)
+      allow(service).to receive(:show_service).and_return(service_attrs)
+      allow(api_spec_resource).to receive(:to_json).and_return(oas_body)
+    end
+
+    context 'creates activedocs' do
+      it 'with name as title' do
+        expect(threescale_client).to receive(:create_activedocs)
+          .with(hash_including(name: title)).and_return({})
+        subject.call
+      end
+
+      it 'with description as api_spec.description' do
+        expect(threescale_client).to receive(:create_activedocs)
+          .with(hash_including(description: description)).and_return({})
+        subject.call
+      end
+
+      it 'with service_id' do
+        expect(threescale_client).to receive(:create_activedocs)
+          .with(hash_including(service_id: service_id)).and_return({})
+        subject.call
+      end
+
+      it 'with system name' do
+        expect(threescale_client).to receive(:create_activedocs)
+          .with(hash_including(system_name: service_system_name)).and_return({})
+        subject.call
+      end
+
+      it 'with body' do
+        expect(threescale_client).to receive(:create_activedocs)
+          .with(hash_including(body: oas_body)).and_return({})
+        subject.call
+      end
+    end
+
+    context 'creates activedocs and returns error' do
+      before :each do
+        expect(threescale_client).to receive(:create_activedocs)
+          .and_return('errors' => { 'system_name' => ['some error ocurred'] })
+      end
+
+      it 'then raises error' do
+        expect { subject.call }.to raise_error(ThreeScaleToolbox::Error, /some error ocurred/)
+      end
+    end
+
+    context 'when activedocs already exists' do
+      before :each do
+        expect(threescale_client).to receive(:create_activedocs)
+          .and_return('errors' => {'system_name' => ['has already been taken']})
+        expect(threescale_client).to receive(:list_activedocs)
+          .and_return(activedocs_list)
+      end
+
+      it 'then updates activedocs with expected id' do
+        expect(threescale_client).to receive(:update_activedocs).with(2, anything).and_return({})
+        expect { subject.call }.to output.to_stdout
+      end
+    end
+  end
+end

--- a/spec/unit/commands/import_command/openapi_spec.rb
+++ b/spec/unit/commands/import_command/openapi_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::OpenAPISubco
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateServiceStep,
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMethodsStep,
           ThreeScaleToolbox::Tasks::DestroyMappingRulesTask,
-          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMappingRulesStep
+          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMappingRulesStep,
+          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActiveDocsStep
         ].each do |task_class|
           task = instance_double(task_class.to_s)
           task_class_obj = class_double(task_class).as_stubbed_const


### PR DESCRIPTION
The OpenAPI Specification used to create the service is pushed as an ActiveDocs file, using the same system_name as the service.

This PR partially covers issue #90 
Still missing: This OpenAPI Specification is patched to take into account the new environment:
* the host field is updated with the hostname component of the public production base URL
* the schemes field is updated with the scheme component of the public production base URL
* the basePath field is updated if rewriting rules have been set
* the securityDefinitions/*/authorizationUrl and securityDefinitions/*/tokenUrl fields are updated with the token and authorize endpoints listed in the OpenID Connect wellknown endpoint (when OIDC is in use)

The missing parts will be included in another PR