### PR TITLE
ActiveDocs created in published state

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -3,13 +3,12 @@
 Features:
 
 * OpenAPI __2.0__ specification (f.k.a. __swagger__)
-* Create a new service. New service name will be taken from openapi definition `info.title` field.
-* Update existing service, providing `system_name` optional parameter. If service with that `system_name` does not exist, create it first.
-`system_name` can be passed as option parameter and defaults to *info.title* field from openapi spec.
+* Update existing service or create a new one. Service's `system_name` can be passed as option parameter and defaults to *info.title* field from openapi spec.
 * Create methods in the 'Definition' section. Method names are taken from `operation.operationId` field.
 * Attach newly created methods to the *Hits* metric.
 * All existing *mapping rules* are deleted before importing new API definition. Methods not deleted if exist before running the command.
 * Create mapping rules and show them under `API > Integration`.
+* Create ActiveDocs.
 * Perform schema validation.
 * OpenAPI definition resource can be provided by one of the following channels:
   * *Filename* in the available path.
@@ -30,6 +29,7 @@ DESCRIPTION
     Using an API definition format like OpenAPI, import to your 3scale API
 
 OPTIONS
+       --activedocs-hidden               Create ActiveDocs in hidden state
     -d --destination=<value>             3scale target instance. Format:
                                          "http[s]://<authentication>@3scale_domain"
     -t --target_system_name=<value>      Target system name
@@ -43,18 +43,6 @@ OPTIONS FOR IMPORT
                                          connections otherwise considered
                                          insecure
     -v --version                         Prints the version of this command
-```
-
-### Create new service
-
-```shell
-$ 3scale import openapi -d <destination> <openapi_resource>
-```
-
-### Update existing service
-
-```shell
-$ 3scale import openapi --target_system_name <TARGET_SYSTEM_NAME> -d <destination> <openapi_resource>
 ```
 
 ### OpenAPI definition from filename in path

--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -27,6 +27,7 @@ module ThreeScaleToolbox
 
               option  :d, :destination, '3scale target instance. Format: "http[s]://<authentication>@3scale_domain"', argument: :required
               option  :t, 'target_system_name', 'Target system name', argument: :required
+              flag    nil, 'activedocs-hidden', 'Create ActiveDocs in hidden state'
               param   :openapi_resource
 
               runner OpenAPISubcommand
@@ -34,9 +35,6 @@ module ThreeScaleToolbox
           end
 
           def run
-            openapi_resource = load_resource(arguments[:openapi_resource])
-            context = create_context(openapi_resource)
-
             tasks = []
             tasks << CreateServiceStep.new(context)
             tasks << CreateMethodsStep.new(context)
@@ -50,12 +48,18 @@ module ThreeScaleToolbox
 
           private
 
-          def create_context(openapi_resource)
+          def context
+            @context ||= create_context
+          end
+
+          def create_context
+            openapi_resource = load_resource(arguments[:openapi_resource])
             {
               api_spec_resource: openapi_resource,
               api_spec: ThreeScaleApiSpec.new(load_openapi(openapi_resource)),
               threescale_client: threescale_client(fetch_required_option(:destination)),
-              target_system_name: options[:target_system_name]
+              target_system_name: options[:target_system_name],
+              activedocs_published: !options[:'activedocs-hidden']
             }
           end
 

--- a/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
@@ -11,7 +11,8 @@ module ThreeScaleToolbox
               system_name: activedocs_system_name,
               service_id: service.id,
               body: resource.to_json,
-              description: api_spec.description
+              description: api_spec.description,
+              published: true,
             }
 
             res = threescale_client.create_activedocs(active_doc)

--- a/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
@@ -10,9 +10,9 @@ module ThreeScaleToolbox
               name: api_spec.title,
               system_name: activedocs_system_name,
               service_id: service.id,
-              body: resource.to_json,
+              body: JSON.pretty_generate(resource),
               description: api_spec.description,
-              published: true,
+              published: context[:activedocs_published]
             }
 
             res = threescale_client.create_activedocs(active_doc)

--- a/spec/integration/import_openapi_spec.rb
+++ b/spec/integration/import_openapi_spec.rb
@@ -119,7 +119,7 @@ RSpec.shared_examples 'oas imported' do
   end
   let(:mapping_rule_keys) { %w[pattern http_method delta] }
   let(:service_active_docs) { service.list_activedocs }
-  let(:oas_resource_json) { YAML.safe_load(File.read(oas_resource_path)).to_json }
+  let(:oas_resource_json) { JSON.pretty_generate(YAML.safe_load(File.read(oas_resource_path))) }
 
   it 'methods are created' do
     expect { subject }.to output.to_stdout

--- a/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActive
           .with(hash_including(body: oas_body)).and_return({})
         subject.call
       end
+
+      it 'with published flag as true' do
+        expect(threescale_client).to receive(:create_activedocs)
+          .with(hash_including(published: true)).and_return({})
+        subject.call
+      end
     end
 
     context 'creates activedocs and returns error' do

--- a/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
@@ -1,15 +1,16 @@
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActiveDocsStep do
-  let(:service) { double('service') }
   let(:api_spec_resource) { double('api_spec_resource') }
   let(:api_spec) { double('api_spec') }
   let(:service) { double('service') }
   let(:threescale_client) { double('threescale_client') }
+  let(:published) { true }
   let(:openapi_context) do
     {
       api_spec_resource: api_spec_resource,
       target: service,
       api_spec: api_spec,
-      threescale_client: threescale_client
+      threescale_client: threescale_client,
+      activedocs_published: published
     }
   end
   let(:title) { 'Some Title' }
@@ -72,6 +73,15 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActive
         expect(threescale_client).to receive(:create_activedocs)
           .with(hash_including(published: true)).and_return({})
         subject.call
+      end
+
+      context 'context published is false' do
+        let(:published) { false }
+        it 'with published flag as false' do
+          expect(threescale_client).to receive(:create_activedocs)
+            .with(hash_including(published: false)).and_return({})
+          subject.call
+        end
       end
     end
 


### PR DESCRIPTION
When importing OAS, ActiveDoc is created by default on `visible` state

Fixes #108 