### PR TITLE
Import openapi bypass validation

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -9,7 +9,7 @@ Features:
 * All existing *mapping rules* are deleted before importing new API definition. Methods not deleted if exist before running the command.
 * Create mapping rules and show them under `API > Integration`.
 * Create ActiveDocs.
-* Perform schema validation.
+* OpenAPI Specification 2.0 JSON Schema validation. Can be skipped with command flag `--skip-openapi-validation`.
 * OpenAPI definition resource can be provided by one of the following channels:
   * *Filename* in the available path.
   * *URL* format. Toolbox will try to download from given address.
@@ -32,6 +32,7 @@ OPTIONS
        --activedocs-hidden               Create ActiveDocs in hidden state
     -d --destination=<value>             3scale target instance. Format:
                                          "http[s]://<authentication>@3scale_domain"
+       --skip-openapi-validation         Skip OpenAPI schema validation
     -t --target_system_name=<value>      Target system name
 
 OPTIONS FOR IMPORT

--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -27,6 +27,7 @@ module ThreeScaleToolbox
               option  :d, :destination, '3scale target instance. Format: "http[s]://<authentication>@3scale_domain"', argument: :required
               option  :t, 'target_system_name', 'Target system name', argument: :required
               flag    nil, 'activedocs-hidden', 'Create ActiveDocs in hidden state'
+              flag    nil, 'skip-openapi-validation', 'Skip OpenAPI schema validation'
               param   :openapi_resource
 
               runner OpenAPISubcommand
@@ -58,12 +59,13 @@ module ThreeScaleToolbox
               api_spec: ThreeScaleApiSpec.new(load_openapi(openapi_resource)),
               threescale_client: threescale_client(fetch_required_option(:destination)),
               target_system_name: options[:target_system_name],
-              activedocs_published: !options[:'activedocs-hidden']
+              activedocs_published: !options[:'activedocs-hidden'],
+              skip_openapi_validation: options[:'skip-openapi-validation']
             }
           end
 
           def load_openapi(openapi_resource)
-            Swagger.build(openapi_resource)
+            Swagger.build(openapi_resource, validate: !options[:'skip-openapi-validation'])
           rescue JSON::Schema::ValidationError => e
             raise ThreeScaleToolbox::Error, "OpenAPI schema validation failed: #{e.message}"
           end

--- a/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
@@ -12,7 +12,8 @@ module ThreeScaleToolbox
               service_id: service.id,
               body: JSON.pretty_generate(resource),
               description: api_spec.description,
-              published: context[:activedocs_published]
+              published: context[:activedocs_published],
+              skip_swagger_validations: context[:skip_openapi_validation]
             }
 
             res = threescale_client.create_activedocs(active_doc)

--- a/lib/3scale_toolbox/commands/import_command/openapi/method.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/method.rb
@@ -16,7 +16,7 @@ module ThreeScaleToolbox
           end
 
           def system_name
-            friendly_name.downcase
+            friendly_name.downcase.gsub(/[^\w]/, '_')
           end
 
           def operation_id

--- a/lib/3scale_toolbox/swagger/swagger.rb
+++ b/lib/3scale_toolbox/swagger/swagger.rb
@@ -4,9 +4,11 @@ module ThreeScaleToolbox
   module Swagger
     META_SCHEMA_PATH = File.expand_path('../../../resources/swagger_meta_schema.json', __dir__)
 
-    def self.build(raw_specification)
-      meta_schema = JSON.parse(File.read(META_SCHEMA_PATH))
-      JSON::Validator.validate!(meta_schema, raw_specification)
+    def self.build(raw_specification, validate: true)
+      if validate
+        meta_schema = JSON.parse(File.read(META_SCHEMA_PATH))
+        JSON::Validator.validate!(meta_schema, raw_specification)
+      end
 
       Specification.new(raw_specification)
     end

--- a/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActive
   let(:service) { double('service') }
   let(:threescale_client) { double('threescale_client') }
   let(:published) { true }
+  let(:skip_openapi_validation) { false }
   let(:openapi_context) do
     {
       api_spec_resource: api_spec_resource,
       target: service,
       api_spec: api_spec,
       threescale_client: threescale_client,
-      activedocs_published: published
+      activedocs_published: published,
+      skip_openapi_validation: skip_openapi_validation,
     }
   end
   let(:title) { 'Some Title' }
@@ -75,11 +77,26 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActive
         subject.call
       end
 
+      it 'with skip_swagger_validations flag as false' do
+        expect(threescale_client).to receive(:create_activedocs)
+          .with(hash_including(skip_swagger_validations: false)).and_return({})
+        subject.call
+      end
+
       context 'context published is false' do
         let(:published) { false }
         it 'with published flag as false' do
           expect(threescale_client).to receive(:create_activedocs)
             .with(hash_including(published: false)).and_return({})
+          subject.call
+        end
+      end
+
+      context 'context skip_openapi_validation is true' do
+        let(:skip_openapi_validation) { true }
+        it 'with skip_swagger_validations flag  as true' do
+          expect(threescale_client).to receive(:create_activedocs)
+            .with(hash_including(skip_swagger_validations: true)).and_return({})
           subject.call
         end
       end

--- a/spec/unit/commands/import_command/openapi/method_spec.rb
+++ b/spec/unit/commands/import_command/openapi/method_spec.rb
@@ -19,7 +19,11 @@ RSpec.describe 'OpenAPI Method' do
     end
 
     it 'contains "system_name"' do
-      is_expected.to include('system_name' => operationId.downcase)
+      is_expected.to include('system_name')
+    end
+
+    it '"system_name" is sanitized' do
+      is_expected.to include('system_name' => 'some_operation_id')
     end
   end
 

--- a/spec/unit/swagger/swagger_spec.rb
+++ b/spec/unit/swagger/swagger_spec.rb
@@ -2,7 +2,8 @@ require '3scale_toolbox'
 
 RSpec.describe ThreeScaleToolbox::Swagger do
   let(:raw_specification) { YAML.safe_load(content) }
-  subject { described_class.build(raw_specification) }
+  let(:validate) { true }
+  subject { described_class.build(raw_specification, validate: validate) }
   let(:title) { 'some info title' }
   let(:description) { 'some info description' }
   let(:base_path) { '/v2' }
@@ -52,6 +53,14 @@ RSpec.describe ThreeScaleToolbox::Swagger do
     it 'should raise error' do
       expect { subject }.to raise_error(JSON::Schema::ValidationError)
     end
+
+    context 'but when validation skipped' do
+      let(:validate) { false }
+
+      it 'should not raise error' do
+        expect { subject }.not_to raise_error(JSON::Schema::ValidationError)
+      end
+    end
   end
 
   context 'missing paths' do
@@ -68,6 +77,14 @@ RSpec.describe ThreeScaleToolbox::Swagger do
 
     it 'should raise error' do
       expect { subject }.to raise_error(JSON::Schema::ValidationError)
+    end
+
+    context 'but when validation skipped' do
+      let(:validate) { false }
+
+      it 'should not raise error' do
+        expect { subject }.not_to raise_error(JSON::Schema::ValidationError)
+      end
     end
   end
 


### PR DESCRIPTION
The 3scale toolbox detects the provided file does not match the `OpenAPI Specification 2.0 JSON Schema` and prints an error message.

The command is re-run with an additional parameter to skip the OpenAPI Specification validation. When the ActiveDocs is created or updated, the `skip_swagger_validations` field is set to true.

The metric `system_name` field is properly sanitized

Fixes #111 