### PR TITLE
verbose mode on 3scale-api-ruby client calls

### DIFF
--- a/lib/3scale_toolbox.rb
+++ b/lib/3scale_toolbox.rb
@@ -1,6 +1,7 @@
 require '3scale_toolbox/version'
 require '3scale_toolbox/helper'
 require '3scale_toolbox/error'
+require '3scale_toolbox/proxy_logger'
 require '3scale_toolbox/swagger'
 require '3scale_toolbox/configuration'
 require '3scale_toolbox/remotes'

--- a/lib/3scale_toolbox/3scale_client_factory.rb
+++ b/lib/3scale_toolbox/3scale_client_factory.rb
@@ -1,17 +1,18 @@
 module ThreeScaleToolbox
   class ThreeScaleClientFactory
     class << self
-      def get(remotes, remote_str, verify_ssl)
-        new(remotes, remote_str, verify_ssl).call
+      def get(remotes, remote_str, verify_ssl, verbose = false)
+        new(remotes, remote_str, verify_ssl, verbose).call
       end
     end
 
-    attr_reader :remotes, :remote_str, :verify_ssl
+    attr_reader :remotes, :remote_str, :verify_ssl, :verbose
 
-    def initialize(remotes, remote_str, verify_ssl)
+    def initialize(remotes, remote_str, verify_ssl, verbose)
       @remotes = remotes
       @remote_str = remote_str
       @verify_ssl = verify_ssl
+      @verbose = verbose
     end
 
     def call
@@ -21,7 +22,10 @@ module ThreeScaleToolbox
         remote = remotes.fetch(remote_str)
       end
 
-      remote_client(remote.merge(verify_ssl: verify_ssl))
+      client = remote_client(remote.merge(verify_ssl: verify_ssl))
+      return ProxyLogger.new(client) if verbose
+
+      client
     end
 
     private

--- a/lib/3scale_toolbox/base_command.rb
+++ b/lib/3scale_toolbox/base_command.rb
@@ -47,12 +47,16 @@ module ThreeScaleToolbox
     # Input param can be endpoint url or remote name
     #
     def threescale_client(str)
-      ThreeScaleClientFactory.get(remotes, str, verify_ssl)
+      ThreeScaleClientFactory.get(remotes, str, verify_ssl, verbose)
     end
 
     def verify_ssl
       # this is flag. It is either true or false. Cannot be nil
       !options[:insecure]
+    end
+
+    def verbose
+      options[:verbose]
     end
 
     def exit_with_message(message)

--- a/lib/3scale_toolbox/commands/3scale_command.rb
+++ b/lib/3scale_toolbox/commands/3scale_command.rb
@@ -19,6 +19,7 @@ module ThreeScaleToolbox
             exit 0
           end
           flag :k, :insecure, 'Proceed and operate even for server connections otherwise considered insecure'
+          flag nil, :verbose, 'Verbose mode'
           flag :h, :help, 'show help for this command' do |_, cmd|
             puts cmd.help
             exit 0

--- a/lib/3scale_toolbox/proxy_logger.rb
+++ b/lib/3scale_toolbox/proxy_logger.rb
@@ -1,0 +1,20 @@
+module ThreeScaleToolbox
+  class ProxyLogger < BasicObject
+    def initialize(subject)
+      @subject = subject
+    end
+
+    def method_missing(name, *args)
+      start_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      result = @subject.public_send(name, *args)
+    ensure
+      end_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start_time
+      ::Kernel.puts "-- call #{name} args |#{args.inspect[0..100]}| response |#{result.inspect[0..100]}| - (#{end_time}s)"
+      result
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      super
+    end
+  end
+end

--- a/spec/unit/3scale_client_factory_spec.rb
+++ b/spec/unit/3scale_client_factory_spec.rb
@@ -6,24 +6,24 @@ RSpec.describe ThreeScaleToolbox::ThreeScaleClientFactory do
   let(:endpoint) { 'https://example.com' }
   let(:authentication) { '123456789' }
   let(:verify_ssl) { true }
-  let(:origin) do
+  let(:api_info) { { endpoint: endpoint, provider_key: authentication, verify_ssl: verify_ssl } }
+  let(:remote_info) { { endpoint: endpoint, authentication: authentication } }
+  let(:client) { double('client') }
+  let(:verbose) { false }
+  let(:remote_str) do
     u = URI(endpoint)
     u.user = authentication
     u.to_s
   end
-  let(:api_info) { { endpoint: endpoint, provider_key: authentication, verify_ssl: verify_ssl } }
-  let(:remote_info) { { endpoint: endpoint, authentication: authentication } }
-  let(:client) { double('client') }
-  subject { described_class.get(remotes, remote_str, verify_ssl) }
+  subject { described_class.get(remotes, remote_str, verify_ssl, verbose) }
 
   context '#call' do
-    context 'remote url param' do
-      let(:remote_str) { origin }
+    before :each do
+      expect(threescale_api).to receive(:new).with(api_info).and_return(client)
+    end
 
-      it 'client is returned' do
-        expect(threescale_api).to receive(:new).with(api_info).and_return(client)
-        expect(subject).to eq(client)
-      end
+    it 'client is returned' do
+      expect(subject).to eq(client)
     end
 
     context 'remote name param' do
@@ -31,8 +31,18 @@ RSpec.describe ThreeScaleToolbox::ThreeScaleClientFactory do
 
       it 'client is returned' do
         expect(remotes).to receive(:fetch).with(remote_str).and_return(remote_info)
-        expect(threescale_api).to receive(:new).with(api_info).and_return(client)
         expect(subject).to eq(client)
+      end
+    end
+
+    context 'verbose mode' do
+      let(:verbose) { true }
+
+      it 'proxy client is returned' do
+        proxy_logger = class_double('ThreeScaleToolbox::ProxyLogger').as_stubbed_const
+        proxied_client = double('proxied_client')
+        expect(proxy_logger).to receive(:new).with(client).and_return(proxied_client)
+        expect(subject).to eq(proxied_client)
       end
     end
   end

--- a/spec/unit/proxy_logger_spec.rb
+++ b/spec/unit/proxy_logger_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe ThreeScaleToolbox::ProxyLogger do
+  class MyTestObject
+    def method01(_param01)
+      'result01'
+    end
+  end
+
+  let(:proxied_object) { MyTestObject.new }
+  subject { described_class.new(proxied_object) }
+
+  it 'method01 exists' do
+    expect(subject.method01('some_param')).to eq('result01')
+  end
+
+  it 'method01 method can be obtained from :method' do
+    expect(subject.method(:method01).to_s).to eq(MyTestObject.new.method(:method01).to_s)
+  end
+
+  it 'undefined method02 raises method not found' do
+    expect { subject.method02 }.to raise_error(NoMethodError)
+  end
+
+  it 'undefined method02 does not exist' do
+    expect(subject.respond_to?(:method02)).to be_falsey
+  end
+
+  it 'proxy object class defined to be proxied object class' do
+    expect(subject.class).to be(MyTestObject)
+  end
+
+  it 'method args in output' do
+    expect do
+      subject.method01('some_param')
+    end.to output(/args \|\["some_param"\]\|/).to_stdout
+  end
+
+  it 'method return values in output' do
+    expect do
+      subject.method01('')
+    end.to output(/response \|"result01"\|/).to_stdout
+  end
+end


### PR DESCRIPTION
Verbose mode for debugging purposes.
Currently just PoC to be reviewed. Only activated for 3scale API calls, showing parameters sent and returned data, just at library level, not http level.

Method name, arguments and returned result are logged, together with call spent time . Truncated for readability.

Execution example:
```shell
3scale --verbose import openapi -d supertest https://petstore.swagger.io/v2/swagger.json
-- call create_service args |[{"name"=>"Swagger Petstore", "descriptio| response |{"errors"=>{"system_name"=>["has already | - (0.466925691s)
-- call list_services args |[]| response |[{"id"=>2555417723913, "name"=>"Default A| - (0.386342888s)
-- call update_service args |[2555417778023, {"name"=>"Swagger Petstor| response |{"id"=>2555417778023, "name"=>"Swagger Pe| - (1.341697979s)
Updated service id: 2555417778023, name: Swagger Petstore
-- call list_metrics args |[2555417778023]| response |[{"id"=>2555418192724, "name"=>"hits", "s| - (1.320869346s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (1.255788086s)
-- call list_metrics args |[2555417778023]| response |[{"id"=>2555418192724, "name"=>"hits", "s| - (0.421487273s)
-- call list_methods args |[2555417778023, 2555418192724]| response |[{"id"=>2555418192725, "name"=>"updatepet| - (0.527233717s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.41484545s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.853302026s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.3730865s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.891086951s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.818100019s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.397594189s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.38975787s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.983790828s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.548324586s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.945861828s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.999151823s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.559096439s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.550227549s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (1.152494071s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.384814473s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.485156714s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.54712834s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (0.387559833s)
-- call create_method args |[2555417778023, 2555418192724, {"friendly| response |{"errors"=>{"system_name"=>["has already | - (1.005019602s)
destroying all mapping rules
-- call list_mapping_rules args |[2555417778023]| response |[{"id"=>379740, "metric_id"=>255541819272| - (0.520080307s)
-- call delete_mapping_rule args |[2555417778023, 379740]| response |true| - (1.061655846s)
-- call delete_mapping_rule args |[2555417778023, 379741]| response |true| - (0.438651289s)
```

Fixes #67 