### PR TITLE
Openapi import: update service settings based on security reqs

### DIFF
--- a/3scale_toolbox.gemspec
+++ b/3scale_toolbox.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.4'
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency '3scale-api', '~> 0.1.8'
+  spec.add_dependency '3scale-api', '~> 0.1.9'
   spec.add_dependency 'cri', '~> 2.15'
   spec.add_dependency 'json-schema', '~> 2.8'
 end

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -15,6 +15,9 @@ Features:
   * *URL* format. Toolbox will try to download from given address.
   * Read from *stdin* standard input stream.
 * Applied strict matching on mapping rule patterns
+* When there is no security requirement in swagger spec, the service is considered as an "Open API".
+Toolbox will then add `default_credentials` policy (also called as `anonymous_policy`) if not yet in policy chain (to be idempotent).
+`default_credentials` policy will be configured with userkey provided in optional parameter `--default-credentials-userkey`.
 
 ### Usage
 
@@ -29,21 +32,29 @@ DESCRIPTION
     Using an API definition format like OpenAPI, import to your 3scale API
 
 OPTIONS
-       --activedocs-hidden               Create ActiveDocs in hidden state
-    -d --destination=<value>             3scale target instance. Format:
-                                         "http[s]://<authentication>@3scale_domain"
-       --skip-openapi-validation         Skip OpenAPI schema validation
-    -t --target_system_name=<value>      Target system name
+       --activedocs-hidden                        Create ActiveDocs in hidden
+                                                  state
+    -d --destination=<value>                      3scale target instance.
+                                                  Format:
+                                                  "http[s]://<authentication>@3scale_domain"
+       --default-credentials-userkey=<value>      Default credentials policy
+                                                  userkey
+       --oidc-issuer-endpoint=<value>             OIDC Issuer Endpoint
+       --skip-openapi-validation                  Skip OpenAPI schema validation
+    -t --target_system_name=<value>               Target system name
 
 OPTIONS FOR IMPORT
-    -c --config-file=<value>             3scale toolbox configuration file
-                                         (default:
-                                         /home/eguzki/.3scalerc.yaml)
-    -h --help                            show help for this command
-    -k --insecure                        Proceed and operate even for server
-                                         connections otherwise considered
-                                         insecure
-    -v --version                         Prints the version of this command
+    -c --config-file=<value>                      3scale toolbox
+                                                  configuration file
+                                                  (default:
+                                                  /home/eguzki/.3scalerc.yaml)
+    -h --help                                     show help for this command
+    -k --insecure                                 Proceed and operate even
+                                                  for server connections
+                                                  otherwise considered
+                                                  insecure
+    -v --version                                  Prints the version of this
+                                                  command
 ```
 
 ### OpenAPI definition from filename in path

--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -8,6 +8,9 @@ require '3scale_toolbox/commands/import_command/openapi/create_method_step'
 require '3scale_toolbox/commands/import_command/openapi/create_mapping_rule_step'
 require '3scale_toolbox/commands/import_command/openapi/create_service_step'
 require '3scale_toolbox/commands/import_command/openapi/create_activedocs_step'
+require '3scale_toolbox/commands/import_command/openapi/update_service_proxy_step'
+require '3scale_toolbox/commands/import_command/openapi/update_service_oidc_conf_step'
+require '3scale_toolbox/commands/import_command/openapi/update_policies_step'
 
 module ThreeScaleToolbox
   module Commands
@@ -28,6 +31,8 @@ module ThreeScaleToolbox
               option  :t, 'target_system_name', 'Target system name', argument: :required
               flag    nil, 'activedocs-hidden', 'Create ActiveDocs in hidden state'
               flag    nil, 'skip-openapi-validation', 'Skip OpenAPI schema validation'
+              option  nil, 'oidc-issuer-endpoint', 'OIDC Issuer Endpoint', argument: :required
+              option  nil, 'default-credentials-userkey', 'Default credentials policy userkey', argument: :required
               param   :openapi_resource
 
               runner OpenAPISubcommand
@@ -41,6 +46,9 @@ module ThreeScaleToolbox
             tasks << ThreeScaleToolbox::Tasks::DestroyMappingRulesTask.new(context)
             tasks << CreateMappingRulesStep.new(context)
             tasks << CreateActiveDocsStep.new(context)
+            tasks << UpdateServiceProxyStep.new(context)
+            tasks << UpdateServiceOidcConfStep.new(context)
+            tasks << UpdatePoliciesStep.new(context)
 
             # run tasks
             tasks.each(&:call)
@@ -60,6 +68,8 @@ module ThreeScaleToolbox
               threescale_client: threescale_client(fetch_required_option(:destination)),
               target_system_name: options[:target_system_name],
               activedocs_published: !options[:'activedocs-hidden'],
+              oidc_issuer_endpoint: options[:'oidc-issuer-endpoint'],
+              default_credentials_userkey: options[:'default-credentials-userkey'],
               skip_openapi_validation: options[:'skip-openapi-validation']
             }
           end

--- a/lib/3scale_toolbox/commands/import_command/openapi/create_service_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_service_step.rb
@@ -48,6 +48,7 @@ module ThreeScaleToolbox
             default_service_settings.tap do |svc|
               svc['name'] = service_name
               svc['description'] = service_description
+              svc['backend_version'] = backend_version
             end
           end
 
@@ -61,6 +62,10 @@ module ThreeScaleToolbox
 
           def service_description
             api_spec.description
+          end
+
+          def backend_version
+            api_spec.backend_version
           end
         end
       end

--- a/lib/3scale_toolbox/commands/import_command/openapi/step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/step.rb
@@ -46,6 +46,18 @@ module ThreeScaleToolbox
           def system_name_already_taken_error?(error)
             Array(Hash(error)['system_name']).any? { |msg| msg.match(/has already been taken/) }
           end
+
+          def security
+            api_spec.security
+          end
+
+          def oidc_issuer_endpoint
+            context[:oidc_issuer_endpoint]
+          end
+
+          def default_credentials_userkey
+            context[:default_credentials_userkey]
+          end
         end
       end
     end

--- a/lib/3scale_toolbox/commands/import_command/openapi/update_policies_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/update_policies_step.rb
@@ -1,0 +1,84 @@
+module ThreeScaleToolbox
+  module Commands
+    module ImportCommand
+      module OpenAPI
+        class UpdatePoliciesStep
+          include Step
+
+          ##
+          # Updates Proxy Policies config
+          def call
+            # to be idempotent, we must read first
+            source_policies_settings = service.policies
+            # shallow copy
+            # to detect policies_settings changes, should only be updated setting objects
+            # do not update in-place, otherwise changes will not be detected
+            policies_settings = source_policies_settings.dup
+
+            add_anonymous_access_policy(policies_settings)
+            add_rh_sso_keycloak_role_check_policy(policies_settings)
+
+            return if source_policies_settings == policies_settings
+
+            service.update_policies('policies_config' => policies_settings)
+          end
+
+          private
+
+          def add_anonymous_access_policy(policies)
+            # only on 'open api' security req
+            return unless security.nil?
+
+            return if policies.any? { |policy| policy['name'] == 'default_credentials' }
+
+            # Anonymous policy should be before apicast policy
+            # hence, adding as a first element
+            policies.insert(0, anonymous_policy)
+          end
+
+          def anonymous_policy
+            raise ThreeScaleToolbox::Error, 'User key must be provided by ' \
+              '--default-credentials-userkey optional param' \
+              if default_credentials_userkey.nil?
+
+            {
+              'name': 'default_credentials',
+              'version': 'builtin',
+              'configuration': {
+                'auth_type': 'user_key',
+                'user_key': default_credentials_userkey
+              },
+              'enabled': true
+            }
+          end
+
+          def add_rh_sso_keycloak_role_check_policy(policies)
+            # only applies to oauth2 sec type
+            return if security.nil? || security.type != 'oauth2'
+
+            return if policies.any? { |policy| policy['name'] == 'keycloak_role_check' }
+
+            policies << keycloak_policy
+          end
+
+          def keycloak_policy
+            {
+              'name': 'keycloak_role_check',
+              'version': 'builtin',
+              'configuration': {
+                'type': 'whitelist',
+                'scopes': [
+                  {
+                    'realm_roles': [],
+                    'client_roles': security.scopes.map { |scope| { 'name': scope } }
+                  }
+                ]
+              },
+              'enabled': true
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/import_command/openapi/update_service_oidc_conf_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/update_service_oidc_conf_step.rb
@@ -1,0 +1,55 @@
+module ThreeScaleToolbox
+  module Commands
+    module ImportCommand
+      module OpenAPI
+        class UpdateServiceOidcConfStep
+          include Step
+
+          ##
+          # Updates OIDC config
+          def call
+            # setting required attrs, operation is idempotent
+            oidc_settings = {}
+
+            add_flow_settings(oidc_settings)
+
+            return unless oidc_settings.size.positive?
+
+            service.update_oidc oidc_settings
+            puts 'Service oidc updated'
+          end
+
+          private
+
+          def add_flow_settings(settings)
+            # only applies to oauth2 sec type
+            return if security.nil? || security.type != 'oauth2'
+
+            oidc_configuration = {
+              standard_flow_enabled: false,
+              implicit_flow_enabled: false,
+              service_accounts_enabled: false,
+              direct_access_grants_enabled: false
+            }.merge(flow => true)
+            settings.merge!(oidc_configuration)
+          end
+
+          def flow
+            case (flow_f = security.flow)
+            when 'implicit'
+              :implicit_flow_enabled
+            when 'password'
+              :direct_access_grants_enabled
+            when 'application'
+              :service_accounts_enabled
+            when 'accessCode'
+              :standard_flow_enabled
+            else
+              raise ThreeScaleToolbox::Error, "Unexpected security flow field #{flow_f}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
@@ -1,0 +1,62 @@
+module ThreeScaleToolbox
+  module Commands
+    module ImportCommand
+      module OpenAPI
+        class UpdateServiceProxyStep
+          include Step
+
+          ##
+          # Updates Proxy config
+          def call
+            # setting required attrs, operation is idempotent
+            proxy_settings = {}
+
+            add_api_backend_settings(proxy_settings)
+            add_security_proxy_settings(proxy_settings)
+
+            return unless proxy_settings.size.positive?
+
+            service.update_proxy proxy_settings
+            puts 'Service proxy updated'
+          end
+
+          private
+
+          def add_api_backend_settings(settings)
+            scheme = api_spec.schemes.first || 'https'
+            host = api_spec.host
+
+            settings[:api_backend] = "#{scheme}://#{host}"
+          end
+
+          def add_security_proxy_settings(settings)
+            # nothing to add on proxy settings when no security required in openapi
+            return if security.nil?
+
+            case security.type
+            when 'oauth2'
+              settings[:credentials_location] = 'headers'
+              settings[:oidc_issuer_endpoint] = oidc_issuer_endpoint unless oidc_issuer_endpoint.nil?
+            when 'apiKey'
+              settings[:credentials_location] = credentials_location
+              settings[:auth_user_key] = security.name
+            else
+              raise ThreeScaleToolbox::Error, "Unexpected security scheme type #{security.type}"
+            end
+          end
+
+          def credentials_location
+            case (in_f = security.in_f)
+            when 'query'
+              'query'
+            when 'header'
+              'headers'
+            else
+              raise ThreeScaleToolbox::Error, "Unexpected security in_f field #{in_f}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/resources/petstore.yaml
+++ b/spec/resources/petstore.yaml
@@ -13,7 +13,7 @@ info:
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-host: petstore.swagger.io
+host: petstore.swagger.io:443
 basePath: /v2
 tags:
   - name: pet
@@ -126,6 +126,9 @@ paths:
         - petstore_auth:
             - 'write:pets'
             - 'read:pets'
+security:
+  - api_key: []
+
 securityDefinitions:
   petstore_auth:
     type: oauth2

--- a/spec/unit/commands/import_command/openapi/create_service_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_service_step_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateServic
     before :example do
       allow(api_spec).to receive(:title).and_return(title)
       allow(api_spec).to receive(:description).and_return(description)
+      allow(api_spec).to receive(:backend_version).and_return('oidc')
     end
 
     context 'when service exists' do
@@ -32,7 +33,8 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateServic
       let(:expected_settings) do
         {
           'name' => title,
-          'description' => description
+          'description' => description,
+          'backend_version' => 'oidc'
         }
       end
 

--- a/spec/unit/commands/import_command/openapi/threescale_api_spec_spec.rb
+++ b/spec/unit/commands/import_command/openapi/threescale_api_spec_spec.rb
@@ -3,9 +3,8 @@ require '3scale_toolbox'
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::ThreeScaleApiSpec do
   let(:title) { 'Some Title' }
   let(:description) { 'Some Description' }
-  context '#parse' do
-    let(:content) do
-      <<~YAML
+  let(:content) do
+    <<~YAML
         ---
         swagger: "2.0"
         info:
@@ -13,6 +12,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::ThreeScaleAp
           description: "#{description}"
           version: "1.0.0"
         basePath: "/v2"
+        schemes: ["https", "http"]
         paths:
           /pet:
             post:
@@ -21,29 +21,180 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::ThreeScaleAp
               responses:
                 405:
                   description: "invalid input"
-      YAML
-    end
-    let(:openapi) { ThreeScaleToolbox::Swagger.build(YAML.safe_load(content)) }
-    subject { described_class.new(openapi) }
+        security:
+          - OauthSecurity:
+            - user
+        securityDefinitions:
+          OauthSecurity:
+            type: oauth2
+            flow: accessCode
+            authorizationUrl: 'https://oauth.simple.api/authorization'
+            tokenUrl: 'https://oauth.simple.api/token'
+            scopes:
+              admin: Admin scope
+              user: User scope
+    YAML
+  end
+  let(:minimum_req_swagger) do
+    <<~YAML
+        ---
+        swagger: "2.0"
+        info:
+          title: "#{title}"
+          version: "1.0.0"
+        paths:
+          /pet:
+            post:
+              operationId: "addPet"
+              responses:
+                405:
+                  description: "invalid input"
+    YAML
+  end
+  let(:openapi) { ThreeScaleToolbox::Swagger.build(YAML.safe_load(content)) }
+  subject { described_class.new(openapi) }
 
-    it 'title available' do
-      expect(subject.title).to eq(title)
+  it 'title available' do
+    expect(subject.title).to eq(title)
+  end
+
+  it 'description available' do
+    expect(subject.description).to eq(description)
+  end
+
+  it 'operations available' do
+    expect(subject.operations).not_to be_nil
+  end
+
+  it 'operations parsed as not empty' do
+    expect(subject.operations).not_to be_empty
+  end
+
+  it 'operations parsed type' do
+    expect(subject.operations[0]).to be_a(ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::Operation)
+  end
+
+  context '#schemes' do
+    it 'schemes match' do
+      expect(subject.schemes).to match_array(%w[https http])
     end
 
-    it 'description available' do
-      expect(subject.description).to eq(description)
+    context 'missing schemes field' do
+      let(:content) { minimum_req_swagger }
+
+      it 'empty array match' do
+        expect(subject.schemes).to match_array([])
+      end
+    end
+  end
+  context '#backend_version' do
+    it 'matches oidc version' do
+      expect(subject.backend_version).to eq('oidc')
     end
 
-    it 'operations available' do
-      expect(subject.operations).not_to be_nil
+    context 'missing security reqs' do
+      let(:content) { minimum_req_swagger }
+
+      it 'matches apiKey version' do
+        expect(subject.backend_version).to eq('1')
+      end
     end
 
-    it 'operations parsed as not empty' do
-      expect(subject.operations).not_to be_empty
+    context 'apiKey security reqs' do
+      let(:content) do
+        <<~YAML
+          ---
+          swagger: "2.0"
+          info:
+            title: "#{title}"
+            version: "1.0.0"
+          paths:
+            /pet:
+              post:
+                operationId: "addPet"
+                responses:
+                  405:
+                    description: "invalid input"
+          security:
+            - MediaSecurity: []
+          securityDefinitions:
+            MediaSecurity:
+              type: apiKey
+              in: query
+              name: media-api-key
+        YAML
+      end
+
+      it 'matches apiKey version' do
+        expect(subject.backend_version).to eq('1')
+      end
     end
 
-    it 'operations parsed type' do
-      expect(subject.operations[0]).to be_a(ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::Operation)
+    context 'basic security reqs' do
+      let(:content) do
+        <<~YAML
+          ---
+          swagger: "2.0"
+          info:
+            title: "#{title}"
+            version: "1.0.0"
+          paths:
+            /pet:
+              post:
+                operationId: "addPet"
+                responses:
+                  405:
+                    description: "invalid input"
+          security:
+            - LegacySecurity: []
+          securityDefinitions:
+            LegacySecurity:
+              type: basic
+        YAML
+      end
+
+      it 'raises error' do
+        expect { subject.backend_version }.to raise_error(ThreeScaleToolbox::Error, /security scheme type/)
+      end
+    end
+  end
+
+  context '#security' do
+    it 'not nil' do
+      expect(subject.security).not_to be_nil
+    end
+
+    context 'multiple security requirements' do
+      let(:content) do
+        <<~YAML
+          ---
+          swagger: "2.0"
+          info:
+            title: "#{title}"
+            version: "1.0.0"
+          paths:
+            /pet:
+              post:
+                operationId: "addPet"
+                responses:
+                  405:
+                    description: "invalid input"
+          security:
+            - MediaSecurity: []
+            - LegacySecurity: []
+          securityDefinitions:
+            MediaSecurity:
+              type: apiKey
+              in: query
+              name: media-api-key
+            LegacySecurity:
+              type: basic
+        YAML
+      end
+
+      it 'raises error' do
+        expect { subject.security }.to raise_error(ThreeScaleToolbox::Error, /multiple security/)
+      end
     end
   end
 end

--- a/spec/unit/commands/import_command/openapi/update_policies_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_policies_spec.rb
@@ -1,0 +1,145 @@
+RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdatePoliciesStep do
+  let(:api_spec) { double('api_spec') }
+  let(:service) { double('service') }
+  let(:default_credentials_userkey) { nil }
+  let(:available_policies) do
+    [
+      {
+        'name' => 'apicast',
+        'version' => 'builtin',
+        'configuration' => {},
+        'enabled' => true
+      }
+    ]
+  end
+  let(:openapi_context) do
+    {
+      target: service,
+      api_spec: api_spec,
+      default_credentials_userkey: default_credentials_userkey
+    }
+  end
+
+  context '#call' do
+    before :each do
+      allow(api_spec).to receive(:security).and_return(security)
+      allow(service).to receive(:policies).and_return(available_policies)
+    end
+    subject { described_class.new(openapi_context).call }
+
+    context 'no sec requirements' do
+      let(:security) { nil }
+      let(:default_credentials_userkey) { '12345' }
+      let(:expected_anonymous_policy_settings) do
+        {
+          name: 'default_credentials',
+          version: 'builtin',
+          configuration: { auth_type: 'user_key', user_key: default_credentials_userkey },
+          enabled: true
+        }
+      end
+
+      it 'anonymous policy is created' do
+        expect(service).to receive(:update_policies)
+          .with(hash_including('policies_config' => array_including(expected_anonymous_policy_settings)))
+        subject
+      end
+
+      context 'no default_credentials_userkey provided' do
+        let(:default_credentials_userkey) { nil }
+        it 'raises error' do
+          expect { subject }.to raise_error(ThreeScaleToolbox::Error, /User key/)
+        end
+      end
+
+      context 'anonymous policy already in chain' do
+        let(:available_policies) do
+          [
+            {
+              'name' => 'default_credentials',
+              'version' => 'builtin',
+              'configuration' => { 'auth_type' => 'user_key', 'user_key': default_credentials_userkey },
+              'enabled' => true
+            }
+          ]
+        end
+
+        it 'policy chain not updated' do
+          # doubles are strict by default.
+          # if service double receives `update_policies` call, test will fail
+          subject
+        end
+      end
+    end
+
+    context 'apiKey sec requirement' do
+      let(:security) do
+        ThreeScaleToolbox::Swagger::SecurityRequirement.new(id: 'apikey', type: 'apiKey',
+                                                            name: 'api_key', in_f: 'query')
+      end
+
+      it 'policy chain not updated' do
+        # doubles are strict by default.
+        # if service double receives `update_policies` call, test will fail
+        subject
+      end
+    end
+
+    context 'oauth2 sec requirement' do
+      let(:scopes) { ['writes:admin'] }
+      let(:security) do
+        ThreeScaleToolbox::Swagger::SecurityRequirement.new(id: 'oidc', type: 'oauth2',
+                                                            flow: 'implicit', scopes: scopes)
+      end
+      let(:expected_keycloak_policy_settings) do
+        {
+          name: 'keycloak_role_check',
+          version: 'builtin',
+          configuration: {
+            type: 'whitelist',
+            scopes: [
+              {
+                realm_roles: [],
+                client_roles: scopes.map { |scope| { 'name': scope } }
+              }
+            ]
+          },
+          enabled: true
+        }
+      end
+
+      it 'keycloak role check policy is created' do
+        expect(service).to receive(:update_policies)
+          .with(hash_including('policies_config' => array_including(expected_keycloak_policy_settings)))
+        subject
+      end
+
+      context 'keycloak role check policy already in chain' do
+        let(:available_policies) do
+          [
+            {
+              'name' => 'keycloak_role_check',
+              'version' => 'builtin',
+              'configuration' => {
+                'type' => 'whitelist',
+                'scopes' => [
+                  {
+                    'realm_roles' => [],
+                    'client_roles' => scopes.map { |scope| { 'name': scope } }
+                  }
+                ]
+              },
+              'enabled' => true
+            }
+          ]
+        end
+
+        it 'policy chain not updated' do
+          # doubles are strict by default.
+          # if service double receives `update_policies` call, test will fail
+          subject
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands/import_command/openapi/update_service_oidc_conf_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_service_oidc_conf_spec.rb
@@ -1,0 +1,98 @@
+RSpec.shared_examples 'oidc is updated with required flow' do
+  it 'oidc is updated with required flow' do
+    expect(service).to receive(:update_oidc)
+      .with(hash_including(standard_flow_enabled: expected_standard_flow,
+                           implicit_flow_enabled: expected_implicit_flow,
+                           service_accounts_enabled: expected_service_accounts,
+                           direct_access_grants_enabled: expected_direct_access_grants))
+    subject
+  end
+end
+
+RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServiceOidcConfStep do
+  let(:api_spec) { double('api_spec') }
+  let(:service) { double('service') }
+  let(:openapi_context) do
+    {
+      target: service,
+      api_spec: api_spec
+    }
+  end
+
+  context '#call' do
+    subject { described_class.new(openapi_context).call }
+
+    before :each do
+      allow(api_spec).to receive(:security).and_return(security)
+    end
+
+    context 'no sec requirements' do
+      let(:security) { nil }
+
+      it 'policy chain not updated' do
+        # doubles are strict by default.
+        # if service double receives `update_policies` call, test will fail
+        subject
+      end
+    end
+
+    context 'apiKey sec requirement' do
+      let(:security) do
+        ThreeScaleToolbox::Swagger::SecurityRequirement.new(id: 'apikey', type: 'apiKey',
+                                                            name: 'api_key', in_f: 'query')
+      end
+
+      it 'policy chain not updated' do
+        # doubles are strict by default.
+        # if service double receives `update_policies` call, test will fail
+        subject
+      end
+    end
+
+    context 'oauth2 sec requirement' do
+      let(:expected_standard_flow) { false }
+      let(:expected_implicit_flow) { false }
+      let(:expected_service_accounts) { false }
+      let(:expected_direct_access_grants) { false }
+      let(:security) do
+        ThreeScaleToolbox::Swagger::SecurityRequirement.new(id: 'oidc', type: 'oauth2', flow: flow)
+      end
+
+      context 'flow implicit' do
+        let(:flow) { 'implicit' }
+        let(:expected_implicit_flow) { true }
+
+        it_behaves_like 'oidc is updated with required flow'
+      end
+
+      context 'flow password' do
+        let(:flow) { 'password' }
+        let(:expected_direct_access_grants) { true }
+
+        it_behaves_like 'oidc is updated with required flow'
+      end
+
+      context 'flow application' do
+        let(:flow) { 'application' }
+        let(:expected_service_accounts) { true }
+
+        it_behaves_like 'oidc is updated with required flow'
+      end
+
+      context 'flow accessCode' do
+        let(:flow) { 'accessCode' }
+        let(:expected_standard_flow) { true }
+
+        it_behaves_like 'oidc is updated with required flow'
+      end
+
+      context 'unexpected flow' do
+        let(:flow) { 'invalidFlow' }
+
+        it 'raises error' do
+          expect { subject }.to raise_error(ThreeScaleToolbox::Error, /security flow/)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServiceProxyStep do
+  let(:api_spec) { double('api_spec') }
+  let(:service) { double('service') }
+  let(:schemes) { [] }
+  let(:host) { 'example.com' }
+  let(:oidc_issuer_endpoint) { 'https://sso.example.com' }
+  let(:openapi_context) do
+    {
+      target: service,
+      api_spec: api_spec,
+      oidc_issuer_endpoint: oidc_issuer_endpoint
+    }
+  end
+
+  context '#call' do
+    subject { described_class.new(openapi_context).call }
+
+    before :each do
+      allow(api_spec).to receive(:schemes).and_return(schemes)
+      allow(api_spec).to receive(:host).and_return(host)
+      allow(api_spec).to receive(:security).and_return(security)
+    end
+
+    context 'no sec requirements' do
+      let(:security) { nil }
+
+      it 'updates proxy' do
+        expect(service).to receive(:update_proxy)
+          .with(hash_including(api_backend: 'https://example.com'))
+        subject
+      end
+    end
+    context 'apiKey sec requirement' do
+      let(:key_name) { 'some_name' }
+      let(:security) do
+        ThreeScaleToolbox::Swagger::SecurityRequirement.new(id: 'apikey', type: 'apiKey',
+                                                            name: key_name, in_f: cred_location)
+      end
+
+      context 'cred location query' do
+        let(:cred_location) { 'query' }
+
+        it 'updates proxy' do
+          expect(service).to receive(:update_proxy)
+            .with(hash_including(
+                    api_backend: 'https://example.com',
+                    credentials_location: 'query',
+                    auth_user_key: key_name
+                  ))
+          subject
+        end
+      end
+
+      context 'cred location header' do
+        let(:cred_location) { 'header' }
+
+        it 'updates proxy' do
+          expect(service).to receive(:update_proxy)
+            .with(hash_including(
+                    api_backend: 'https://example.com',
+                    credentials_location: 'headers',
+                    auth_user_key: key_name
+                  ))
+          subject
+        end
+      end
+
+      context 'unexpected cred location' do
+        let(:cred_location) { 'unexpected_cred_location' }
+
+        it 'raises error' do
+          expect { subject }.to raise_error(ThreeScaleToolbox::Error, /in_f field/)
+        end
+      end
+    end
+
+    context 'oauth2 sec requirement' do
+      let(:security) do
+        ThreeScaleToolbox::Swagger::SecurityRequirement.new(id: 'oidc', type: 'oauth2',
+                                                            flow: 'implicit')
+      end
+
+      it 'updates proxy' do
+        expect(service).to receive(:update_proxy)
+          .with(hash_including(
+                  api_backend: 'https://example.com',
+                  credentials_location: 'headers',
+                  oidc_issuer_endpoint: oidc_issuer_endpoint
+                ))
+        subject
+      end
+    end
+  end
+end

--- a/spec/unit/commands/import_command/openapi_spec.rb
+++ b/spec/unit/commands/import_command/openapi_spec.rb
@@ -27,7 +27,10 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::OpenAPISubco
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMethodsStep,
           ThreeScaleToolbox::Tasks::DestroyMappingRulesTask,
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMappingRulesStep,
-          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActiveDocsStep
+          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActiveDocsStep,
+          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServiceProxyStep,
+          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServiceOidcConfStep,
+          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdatePoliciesStep,
         ].each do |task_class|
           task = instance_double(task_class.to_s)
           task_class_obj = class_double(task_class).as_stubbed_const


### PR DESCRIPTION
Set the correct service authentication settings when importing an OpenAPI Specification based on security requirements.

- [x] Update swagger parser to parse security requirements and definitions (schemes)
- [x] Update service api_backend (private base URL)
- [x] Update service auth mode (backend_version)
- [x] Update service auth settings for apiKey mode
- [x] Update service auth settings for oidc mode
- [x] Update service auth settings when no auth is specified
- [x] tests

Fixes #92 

Partially implementing #91, but not fully, just setting `private base URL`