### PR TITLE
Import openapi: update url-rewritting policy

### DIFF
--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -33,6 +33,8 @@ module ThreeScaleToolbox
               flag    nil, 'skip-openapi-validation', 'Skip OpenAPI schema validation'
               option  nil, 'oidc-issuer-endpoint', 'OIDC Issuer Endpoint', argument: :required
               option  nil, 'default-credentials-userkey', 'Default credentials policy userkey', argument: :required
+              option  nil, 'override-private-basepath', 'Override the basepath for the public URLs', argument: :required
+              option  nil, 'override-public-basepath', 'Override the basepath for the private URLs', argument: :required
               param   :openapi_resource
 
               runner OpenAPISubcommand
@@ -64,13 +66,14 @@ module ThreeScaleToolbox
             openapi_resource = load_resource(arguments[:openapi_resource])
             {
               api_spec_resource: openapi_resource,
-              api_spec: ThreeScaleApiSpec.new(load_openapi(openapi_resource)),
+              api_spec: ThreeScaleApiSpec.new(load_openapi(openapi_resource), options[:'override-public-basepath']),
               threescale_client: threescale_client(fetch_required_option(:destination)),
               target_system_name: options[:target_system_name],
               activedocs_published: !options[:'activedocs-hidden'],
               oidc_issuer_endpoint: options[:'oidc-issuer-endpoint'],
               default_credentials_userkey: options[:'default-credentials-userkey'],
-              skip_openapi_validation: options[:'skip-openapi-validation']
+              skip_openapi_validation: options[:'skip-openapi-validation'],
+              override_private_basepath: options[:'override-private-basepath']
             }
           end
 

--- a/lib/3scale_toolbox/commands/import_command/openapi/mapping_rule.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/mapping_rule.rb
@@ -18,7 +18,17 @@ module ThreeScaleToolbox
 
           def pattern
             # apply strict matching
-            operation[:path] + '$'
+            "#{raw_pattern}$"
+          end
+
+          def raw_pattern
+            # According OAS 2.0: path MUST begin with a slash
+            "#{public_base_path}#{operation[:path]}"
+          end
+
+          def public_base_path
+            # remove the last slash of the basePath
+            operation[:public_base_path].gsub(%r{/$}, '')
           end
 
           def delta

--- a/lib/3scale_toolbox/commands/import_command/openapi/step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/step.rb
@@ -58,6 +58,10 @@ module ThreeScaleToolbox
           def default_credentials_userkey
             context[:default_credentials_userkey]
           end
+
+          def override_private_basepath
+            context[:override_private_basepath]
+          end
         end
       end
     end

--- a/lib/3scale_toolbox/commands/import_command/openapi/threescale_api_spec.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/threescale_api_spec.rb
@@ -5,8 +5,9 @@ module ThreeScaleToolbox
         class ThreeScaleApiSpec
           attr_reader :openapi
 
-          def initialize(openapi)
+          def initialize(openapi, base_path = nil)
             @openapi = openapi
+            @base_path = base_path
           end
 
           def title
@@ -46,11 +47,21 @@ module ThreeScaleToolbox
           def operations
             openapi.operations.map do |op|
               Operation.new(
-                path: "#{openapi.base_path}#{op.path}",
+                base_path: base_path,
+                public_base_path: public_base_path,
+                path: op.path,
                 verb: op.verb,
                 operationId: op.operation_id
               )
             end
+          end
+
+          def public_base_path
+            @base_path || base_path
+          end
+
+          def base_path
+            openapi.base_path || '/'
           end
 
           private

--- a/lib/3scale_toolbox/commands/import_command/openapi/update_policies_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/update_policies_step.rb
@@ -17,6 +17,7 @@ module ThreeScaleToolbox
 
             add_anonymous_access_policy(policies_settings)
             add_rh_sso_keycloak_role_check_policy(policies_settings)
+            add_url_rewritting_policy(policies_settings)
 
             return if source_policies_settings == policies_settings
 
@@ -47,13 +48,13 @@ module ThreeScaleToolbox
               if default_credentials_userkey.nil?
 
             {
-              'name': 'default_credentials',
-              'version': 'builtin',
-              'configuration': {
-                'auth_type': 'user_key',
-                'user_key': default_credentials_userkey
+              name: 'default_credentials',
+              version: 'builtin',
+              configuration: {
+                auth_type: 'user_key',
+                user_key: default_credentials_userkey
               },
-              'enabled': true
+              enabled: true
             }
           end
 
@@ -68,19 +69,67 @@ module ThreeScaleToolbox
 
           def keycloak_policy
             {
-              'name': 'keycloak_role_check',
-              'version': 'builtin',
-              'configuration': {
-                'type': 'whitelist',
-                'scopes': [
+              name: 'keycloak_role_check',
+              version: 'builtin',
+              configuration: {
+                type: 'whitelist',
+                scopes: [
                   {
-                    'realm_roles': [],
-                    'client_roles': security.scopes.map { |scope| { 'name': scope } }
+                    realm_roles: [],
+                    client_roles: security.scopes.map { |scope| { 'name': scope } }
                   }
                 ]
               },
-              'enabled': true
+              enabled: true
             }
+          end
+
+          def add_url_rewritting_policy(policies)
+            return if private_base_path == api_spec.public_base_path
+
+            url_rewritting_policy_idx = policies.find_index do |policy|
+              policy['name'] == 'url_rewriting'
+            end
+
+            if url_rewritting_policy_idx.nil?
+              policies << url_rewritting_policy
+            else
+              policies[url_rewritting_policy_idx] = url_rewritting_policy
+            end
+          end
+
+          def private_base_path
+            override_private_basepath || api_spec.base_path
+          end
+
+          def url_rewritting_policy
+            regex = url_rewritting_policy_regex
+            replace = url_rewritting_policy_replace
+            # If regex has a / at the end, replace must have a / at the end
+            replace.concat('/') if regex.end_with?('/') && !replace.end_with?('/')
+
+            {
+              name: 'url_rewriting',
+              version: 'builtin',
+              configuration: {
+                commands: [
+                  {
+                    op: 'sub',
+                    regex: regex,
+                    replace: replace
+                  }
+                ]
+              },
+              enabled: true
+            }
+          end
+
+          def url_rewritting_policy_regex
+            "^#{api_spec.public_base_path}"
+          end
+
+          def url_rewritting_policy_replace
+            "#{private_base_path}"
           end
         end
       end

--- a/spec/custom_matchers.rb
+++ b/spec/custom_matchers.rb
@@ -13,3 +13,13 @@ RSpec::Matchers.define :be_subset_of do |superset|
     @keys = keys
   end
 end
+
+RSpec::Matchers.define :excluding_policies do |policy_name|
+  match do |policies_object|
+    return true unless policies_object.key?('policies_config')
+
+    policies_object['policies_config'].all? do |policy|
+      policy[:name] != policy_name
+    end
+  end
+end

--- a/spec/integration/import_openapi_basepath_spec.rb
+++ b/spec/integration/import_openapi_basepath_spec.rb
@@ -1,0 +1,110 @@
+require '3scale_toolbox'
+
+RSpec.shared_context :import_oas_basepath_stubbed do
+  include_context :oas_common_mocked_context
+
+  let(:external_account) do
+    {
+      'account' => {
+        'id' => 1000
+      }
+    }
+  end
+
+  let(:external_app_plans) do
+    {
+      'application_plan' => {
+        'id' => 2000
+      }
+    }
+  end
+
+  let(:external_app) do
+    {
+      'application' => {
+        'id' => 2000,
+        'user_key' => 987756
+      }
+    }
+  end
+
+  let(:external_proxy) do
+    {
+      'proxy' => {
+        'service_id' => fake_service_id,
+        'endpoint' => 'https://production.gw.apicast.io:443',
+        'sandbox_endpoint' => 'https://staging.gw.apicast.io:443',
+        'api_backend' => 'https://echo-api.3scale.net:443',
+        'credentials_location' => 'query',
+        'auth_app_key' => 'app_key',
+        'auth_app_id' => 'app_id',
+        'oidc_issuer_endpoint' => 'https://issuer.com',
+        'auth_user_key' => 'api_key'
+      }
+    }
+  end
+
+  before :example do
+    allow(external_http_client).to receive(:post).with('/admin/api/signup', anything)
+                                                 .and_return(external_account)
+    allow(external_http_client).to receive(:post).with('/admin/api/services/100/application_plans', anything)
+                                                 .and_return(external_app_plans)
+    allow(external_http_client).to receive(:post).with('/admin/api/accounts/1000/applications', anything)
+                                                 .and_return(external_app)
+    allow(external_http_client).to receive(:delete).with('/admin/api/accounts/1000/applications/2000')
+    allow(external_http_client).to receive(:delete).with('/admin/api/accounts/1000')
+
+    # Stubbed net client
+    body = JSON.dump(path: '/private/pet/findByStatus')
+    stub_request(:get, %r{staging.gw.apicast.io/public/pet/findByStatus})
+      .to_return(body: body, status: 200)
+  end
+end
+
+RSpec.describe 'OpenAPI import basepath diff' do
+  include_context :oas_common_context
+  include_context :import_oas_basepath_stubbed unless ENV.key?('ENDPOINT')
+
+  let(:oas_resource_path) { File.join(resources_path, 'petstore.yaml') }
+
+  let(:command_line_str) do
+    "import openapi -t #{system_name} -d #{destination_url}" \
+    ' --override-private-basepath=/private' \
+    ' --override-public-basepath=/public' \
+    " #{oas_resource_path}"
+  end
+
+  let(:backend_version) { '1' }
+  let(:path) { '/public/pet/findByStatus' }
+  let(:sandbox_host) { service_proxy.fetch('sandbox_endpoint') }
+  let(:account_name) { "account_#{random_lowercase_name}" }
+  let(:account) { api3scale_client.signup(name: account_name, username: account_name) }
+  let(:application_plan) do
+    api3scale_client.create_application_plan(service_id,
+                                             'name' => "appplan_#{random_lowercase_name}")
+  end
+  let(:application) do
+    api3scale_client.create_application(account['id'],
+                                        plan_id: application_plan['id'],
+                                        user_key: random_lowercase_name)
+  end
+  let(:api_key) { application['user_key'] }
+
+  let(:response) do
+    uri = URI("#{sandbox_host}#{path}")
+    uri.query = URI.encode_www_form(api_key: api_key)
+    Net::HTTP.get_response(uri)
+  end
+
+  after :example do
+    api3scale_client.delete_application(account['id'], application['id'])
+    api3scale_client.delete_account(account['id'])
+  end
+
+  it 'request url is rewritten' do
+    expect { subject }.to output.to_stdout
+    expect(subject).to eq(0)
+    expect(response.class).to be(Net::HTTPOK)
+    expect(JSON.parse(response.body)).to include('path' => '/private/pet/findByStatus')
+  end
+end

--- a/spec/integration/import_openapi_oidc_spec.rb
+++ b/spec/integration/import_openapi_oidc_spec.rb
@@ -1,0 +1,46 @@
+require '3scale_toolbox'
+
+RSpec.shared_context :import_oas_oidc_stubbed do
+  include_context :oas_common_mocked_context
+
+  let(:external_proxy) do
+    {
+      'proxy' => {
+        'service_id' => fake_service_id,
+        'endpoint' => 'https://production.gw.apicast.io:443',
+        'sandbox_endpoint' => 'https://staging.gw.apicast.io:443',
+        'api_backend' => 'https://echo-api.3scale.net:443',
+        'credentials_location' => 'headers',
+        'auth_app_key' => 'app_key',
+        'auth_app_id' => 'app_id',
+        'oidc_issuer_endpoint' => 'https://issuer.com',
+        'auth_user_key' => 'api_key'
+      }
+    }
+  end
+end
+
+RSpec.describe 'OpenAPI import OIDC service' do
+  include_context :oas_common_context
+  include_context :import_oas_oidc_stubbed unless ENV.key?('ENDPOINT')
+
+  # render from template to avoid system_name collision
+  let(:oas_resource_path) { File.join(resources_path, 'oidc.yaml') }
+  let(:issuer_endpoint) { 'https://issuer.com' }
+  let(:command_line_str) do
+    "import openapi -t #{system_name} --oidc-issuer-endpoint=#{issuer_endpoint} " \
+    " -d #{destination_url} #{oas_resource_path}"
+  end
+  let(:backend_version) { 'oidc' }
+  let(:credentials_location) { 'headers' }
+
+  it 'oidc settings are updated' do
+    expect { subject }.to output.to_stdout
+    expect(subject).to eq(0)
+    expect(service_settings).not_to be_nil
+    expect(service_settings).to include('backend_version' => backend_version)
+    expect(service_proxy).not_to be_nil
+    expect(service_proxy).to include('oidc_issuer_endpoint' => issuer_endpoint,
+                                     'credentials_location' => credentials_location)
+  end
+end

--- a/spec/resources/petstore.yaml
+++ b/spec/resources/petstore.yaml
@@ -13,7 +13,7 @@ info:
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-host: petstore.swagger.io:443
+host: echo-api.3scale.net:443
 basePath: /v2
 tags:
   - name: pet
@@ -140,7 +140,7 @@ securityDefinitions:
   api_key:
     type: apiKey
     name: api_key
-    in: header
+    in: query 
 definitions:
   Order:
     type: object

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -111,6 +111,15 @@ RSpec.shared_context :real_copy_cleanup do
   end
 end
 
+RSpec.shared_context :import_oas_real_cleanup do
+  after :example do
+    service.list_activedocs.each do |activedoc|
+      service.remote.delete_activedocs(activedoc['id'])
+    end
+    service.delete_service
+  end
+end
+
 RSpec.shared_context :toolbox_tasks_helper do
   let(:tasks_helper) do
     Class.new { include ThreeScaleToolbox::Tasks::Helper }.new
@@ -132,4 +141,119 @@ RSpec.shared_context :copied_metrics do
   let(:target_metrics) { target_service.metrics }
   let(:metric_keys) { %w[name system_name unit] }
   let(:metrics_mapping) { tasks_helper.metrics_mapping(source_metrics, target_metrics) }
+end
+
+RSpec.shared_context :oas_common_context do
+  include_context :resources
+  include_context :random_name
+  if ENV.key?('ENDPOINT')
+    include_context :real_api3scale_client
+    include_context :import_oas_real_cleanup
+  end
+  let(:system_name) { "test_openapi_#{random_lowercase_name}" }
+  let(:destination_url) do
+    endpoint_uri = URI(endpoint)
+    endpoint_uri.user = provider_key
+    endpoint_uri.to_s
+  end
+  subject { ThreeScaleToolbox::CLI.run(command_line_str.split) }
+  let(:service_id) do
+    # figure out service by system_name
+    api3scale_client.list_services.find { |service| service['system_name'] == system_name }['id']
+  end
+  let(:service) do
+    ThreeScaleToolbox::Entities::Service.new(id: service_id, remote: api3scale_client)
+  end
+  let(:service_proxy) { service.show_proxy }
+  let(:service_settings) { service.show_service }
+end
+
+RSpec.shared_context :oas_common_mocked_context do
+  let(:internal_http_client) { double('internal_http_client') }
+  let(:http_client_class) { class_double('ThreeScale::API::HttpClient').as_stubbed_const }
+
+  let(:endpoint) { 'https://example.com' }
+  let(:provider_key) { '123456789' }
+  let(:verify_ssl) { true }
+  let(:external_http_client) { double('external_http_client') }
+  let(:api3scale_client) { ThreeScale::API::Client.new(external_http_client) }
+  let(:fake_service_id) { 100 }
+
+  let(:service_attr) do
+    { 'service' => { 'id' => fake_service_id,
+                     'system_name' => system_name,
+                     'backend_version' => backend_version } }
+  end
+  let(:metrics) do
+    {
+      'metrics' => [
+        { 'metric' => { 'id' => '1', 'system_name' => 'hits' } }
+      ]
+    }
+  end
+
+  let(:service_policies) do
+    {
+      'policies_config' => [
+        { 'name' => 'apicast', 'version' => 'builtin', 'configuration' => {}, 'enabled' => true }
+      ]
+    }
+  end
+
+  let(:existing_mapping_rules) do
+    {
+      'mapping_rules' => [
+        { 'mapping_rule' => { 'id' => '1', 'delta' => 1, 'http_method' => 'GET', 'pattern' => '/' } }
+      ]
+    }
+  end
+
+  let(:existing_services) do
+    {
+      'services' => [
+        { 'service' => { 'id' => fake_service_id, 'system_name' => system_name } }
+      ]
+    }
+  end
+
+  before :example do
+    puts '============ RUNNING STUBBED 3SCALE API CLIENT =========='
+    ##
+    # Internal http client stub
+    allow(internal_http_client).to receive(:post).with('/admin/api/services', anything)
+                                                 .and_return(service_attr)
+    allow(http_client_class).to receive(:new).and_return(internal_http_client)
+    allow(internal_http_client).to receive(:get).with('/admin/api/services/100/metrics')
+                                                .and_return(metrics)
+    allow(internal_http_client).to receive(:post).with('/admin/api/services/100/metrics/1/methods',
+                                                       anything).at_least(:once)
+                                                 .and_return('id' => '1')
+    allow(internal_http_client).to receive(:get).with('/admin/api/services/100/proxy/mapping_rules').and_return(existing_mapping_rules)
+    allow(internal_http_client).to receive(:delete).with('/admin/api/services/100/proxy/mapping_rules/1')
+    allow(internal_http_client).to receive(:post).with('/admin/api/services/100/proxy/mapping_rules', anything)
+                                                 .at_least(:once)
+    allow(internal_http_client).to receive(:post).with('/admin/api/active_docs', anything)
+                                                 .and_return({})
+    allow(internal_http_client).to receive(:get).with('/admin/api/services/100')
+                                                .and_return(service_attr)
+    allow(internal_http_client).to receive(:patch).with('/admin/api/services/100/proxy', anything)
+                                                  .and_return({})
+    allow(internal_http_client).to receive(:get).with('/admin/api/services/100/proxy/policies')
+                                                .and_return(service_policies)
+    allow(internal_http_client).to receive(:patch).with('/admin/api/services/100/proxy/oidc_configuration', anything).and_return({})
+    allow(internal_http_client).to receive(:put).with('/admin/api/services/100/proxy/policies',
+                                                      anything).and_return({})
+    ##
+    # External http client stub
+    allow(external_http_client).to receive(:post).with('/admin/api/services', anything)
+                                                 .and_return(service_attr)
+    allow(external_http_client).to receive(:get).with('/admin/api/services')
+                                                .and_return(existing_services)
+    allow(external_http_client).to receive(:get).with('/admin/api/services/100/metrics')
+                                                .and_return(metrics)
+    allow(external_http_client).to receive(:get).with('/admin/api/services/100/proxy')
+                                                .and_return(external_proxy)
+    allow(external_http_client).to receive(:get).with('/admin/api/services/100')
+                                                .and_return(service_attr)
+  end
 end

--- a/spec/unit/commands/import_command/openapi/mapping_rule_spec.rb
+++ b/spec/unit/commands/import_command/openapi/mapping_rule_spec.rb
@@ -13,11 +13,14 @@ RSpec.describe 'OpenAPI Mapping Rule' do
     let(:verb) { 'POST' }
     let(:path) { '/some/path' }
     let(:metric_id) { '1' }
-    let(:operation) { { verb: verb, path: path, metric_id: metric_id } }
+    let(:public_base_path) { '/v1' }
+    let(:operation) do
+      { verb: verb, path: path, metric_id: metric_id, public_base_path: public_base_path }
+    end
     subject { OpenAPIMappingRuleClass.new(operation).mapping_rule }
 
     it 'contains "pattern"' do
-      is_expected.to include('pattern' => path + '$')
+      is_expected.to include('pattern' => '/v1/some/path$')
     end
 
     it 'contains "http_method"' do
@@ -30,6 +33,13 @@ RSpec.describe 'OpenAPI Mapping Rule' do
 
     it 'contains "metric_id"' do
       is_expected.to include('metric_id' => metric_id)
+    end
+
+    context 'base path ends with /' do
+      let(:public_base_path) { '/v1/' }
+      it 'pattern removes last /' do
+        is_expected.to include('pattern' => '/v1/some/path$')
+      end
     end
   end
 end

--- a/spec/unit/commands/import_command/openapi/update_policies_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_policies_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdatePoliciesStep do
   let(:api_spec) { double('api_spec') }
   let(:service) { double('service') }
-  let(:default_credentials_userkey) { nil }
+  let(:default_credentials_userkey) { '12345' }
+  let(:override_private_basepath) { nil }
   let(:available_policies) do
     [
       {
@@ -16,19 +17,24 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdatePolici
     {
       target: service,
       api_spec: api_spec,
-      default_credentials_userkey: default_credentials_userkey
+      default_credentials_userkey: default_credentials_userkey,
+      override_private_basepath: override_private_basepath
     }
   end
+  let(:security) { nil }
+  let(:base_path) { '/v1' }
+  let(:public_base_path) { '/v1' }
 
   context '#call' do
     before :each do
       allow(api_spec).to receive(:security).and_return(security)
+      allow(api_spec).to receive(:base_path).and_return(base_path)
+      allow(api_spec).to receive(:public_base_path).and_return(public_base_path)
       allow(service).to receive(:policies).and_return(available_policies)
     end
     subject { described_class.new(openapi_context).call }
 
     context 'no sec requirements' do
-      let(:security) { nil }
       let(:default_credentials_userkey) { '12345' }
       let(:expected_anonymous_policy_settings) do
         {
@@ -139,6 +145,96 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdatePolici
         it 'policy chain not updated' do
           # doubles are strict by default.
           # if service double receives `update_policies` call, test will fail
+          subject
+        end
+      end
+    end
+
+    context 'same private and public base paths' do
+      let(:public_base_path) { '/v1' }
+      let(:base_path) { '/v1' }
+
+      it 'url_rewritting policy not added' do
+        expect(service).to receive(:update_policies).with(excluding_policies('url_rewriting'))
+        subject
+      end
+
+      context 'private base path overriden' do
+        let(:public_base_path) { '/v1' }
+        let(:base_path) { '/v2' }
+        let(:override_private_basepath) { '/v1' }
+
+        it 'url_rewritting policy not added' do
+          expect(service).to receive(:update_policies).with(excluding_policies('url_rewriting'))
+          subject
+        end
+      end
+    end
+
+    context 'diff private and public base paths' do
+      let(:public_base_path) { '/v1' }
+      let(:base_path) { '/pets' }
+      let(:regex) { '^/v1' }
+      let(:replace) { '/pets' }
+      let(:url_rewritting_policy) do
+        {
+          name: 'url_rewriting',
+          version: 'builtin',
+          configuration: {
+            commands: [
+              {
+                op: 'sub',
+                regex: regex,
+                replace: replace
+              }
+            ]
+          },
+          enabled: true
+        }
+      end
+
+      it 'url_rewritting added' do
+        expect(service).to receive(:update_policies)
+          .with(hash_including('policies_config' => array_including(url_rewritting_policy)))
+        subject
+      end
+
+      context 'regex has / at the end' do
+        let(:public_base_path) { '/v1/' }
+        let(:base_path) { '/cats' }
+        let(:regex) { '^/v1/' }
+        let(:replace) { '/cats/' }
+
+        it 'replace ends with /' do
+          expect(service).to receive(:update_policies)
+            .with(hash_including('policies_config' => array_including(url_rewritting_policy)))
+          subject
+        end
+      end
+
+      context 'update existing policy' do
+        let(:available_policies) do
+          [
+            {
+              'name' => 'url_rewriting',
+              'version' => 'builtin',
+              'configuration' => {
+                'commands' => [
+                  {
+                    'op' => 'sub',
+                    'regex' => '^/some/path',
+                    'replace' => 'other/path'
+                  }
+                ]
+              },
+              'enabled' => true
+            }
+          ]
+        end
+
+        it 'url_rewritting updated' do
+          expect(service).to receive(:update_policies)
+            .with(hash_including('policies_config' => array_including(url_rewritting_policy)))
           subject
         end
       end


### PR DESCRIPTION
Implements spec from #91 

Specifically https://github.com/3scale/3scale_toolbox/issues/91#issuecomment-475641632

Adding more integration tests on importing OAS was getting complicated to keep up with single mocked results generic for all test. So I ended up putting each integration test on a different file and share common context. Little refactor was required, but I guess the resulting testing code allows adding more e2e tests about importing OAS.