### PR TITLE
Fix copying self managed service to on prem where invalid

### DIFF
--- a/lib/3scale_toolbox/helper.rb
+++ b/lib/3scale_toolbox/helper.rb
@@ -32,6 +32,12 @@ module ThreeScaleToolbox
 
         uri_obj
       end
+
+      def service_invalid_deployment_option?(error)
+        Array(Hash(error)['deployment_option']).any? do |msg|
+          msg.match(/is not included in the list/)
+        end
+      end
     end
   end
 end

--- a/spec/unit/tasks/update_service_settings_task_spec.rb
+++ b/spec/unit/tasks/update_service_settings_task_spec.rb
@@ -5,12 +5,17 @@ RSpec.describe ThreeScaleToolbox::Tasks::UpdateServiceSettingsTask do
     let(:source) { double('source') }
     let(:target) { double('target') }
     let(:target_id) { 2 }
+    let(:deployment_option) { 'hosted' }
     let(:service_settings) do
       {
         'name' => 'some_name',
-        'system_name' => 'old_system_name'
+        'system_name' => 'old_system_name',
+        'deployment_option' => deployment_option
       }
     end
+    let(:service_id) { '1000' }
+    let(:common_error_response) { { 'errors' => { 'comp' => 'error' } } }
+    let(:positive_response) { { 'errors' => nil, 'id' => 'some_id' } }
     let(:target_name) { 'new_name' }
     subject { described_class.new(source: source, target: target, target_name: target_name) }
 
@@ -20,14 +25,40 @@ RSpec.describe ThreeScaleToolbox::Tasks::UpdateServiceSettingsTask do
 
     context 'remote respond with error' do
       it 'error raised' do
-        expect(target).to receive(:update_service).and_return('errors' => 'some error')
+        expect(target).to receive(:update_service).and_return(common_error_response)
+        expect { subject.call }.to raise_error(ThreeScaleToolbox::Error, /not been saved/)
+      end
+    end
+
+    context 'deployment mode invalid' do
+      let(:invalid_deployment_error_response) do
+        {
+          'errors' => {
+            'deployment_option' => ['is not included in the list']
+          }
+        }
+      end
+
+      it 'deployment config is set to hosted' do
+        expect(source).to receive(:id).and_return(service_id)
+        expect(target).to receive(:update_service).with(hash_including('deployment_option'))
+                                                  .and_return(invalid_deployment_error_response)
+        expect(target).to receive(:update_service).with(hash_excluding('deployment_option'))
+                                                  .and_return(positive_response)
+        expect { subject.call }.to output(/updated service settings for service id #{service_id}/).to_stdout
+      end
+
+      it 'throws error when second request returns error' do
+        expect(target).to receive(:update_service).with(hash_including('deployment_option'))
+                                                  .and_return(invalid_deployment_error_response)
+        expect(target).to receive(:update_service).with(hash_excluding('deployment_option'))
+                                                  .and_return(common_error_response)
         expect { subject.call }.to raise_error(ThreeScaleToolbox::Error, /not been saved/)
       end
     end
 
     context 'system_name not provided' do
       let(:target_name) { nil }
-      let(:service_id) { '7' }
       let(:expected_svc_settings) { service_settings.reject { |k, _| k == 'system_name' } }
 
       it 'service settings does not contain system_name' do
@@ -38,7 +69,6 @@ RSpec.describe ThreeScaleToolbox::Tasks::UpdateServiceSettingsTask do
     end
 
     context 'system_name provided' do
-      let(:service_id) { '7' }
       let(:expected_svc_settings) { service_settings.merge('system_name' => target_name) }
 
       it 'service settings contains new provided system_name' do


### PR DESCRIPTION
When copying a service from 3scale SaaS to an On-premises deployment using the toolbox command and APIcast is configured as self-managed gateway: 
```
3scale copy service 12345678 --source=https://<SaaS_provider_key>@<SaaSdomain>-admin.3scale.net --destination=https://<OnPremprovider_key>@3scale-admin.example.com --target_system_name=abcdefg
```

It outputs the following error: 
```
Error: Service has not been saved. Errors: {"deployment_option"=>["is not included in the list"]}
```

The problem is that 3scale On-premises  doesn't have the self-managed gateway option in the configuration. 
