### PR TITLE
proxy update as last task to update proxy object with latest changes

### DIFF
--- a/lib/3scale_toolbox/commands/copy_command/copy_service.rb
+++ b/lib/3scale_toolbox/commands/copy_command/copy_service.rb
@@ -33,7 +33,6 @@ module ThreeScaleToolbox
           puts "new service id #{target_service.id}"
           context = create_context(source_service, target_service)
           tasks = [
-            Tasks::CopyServiceProxyTask.new(context),
             Tasks::CopyMethodsTask.new(context),
             Tasks::CopyMetricsTask.new(context),
             Tasks::CopyApplicationPlansTask.new(context),
@@ -43,6 +42,11 @@ module ThreeScaleToolbox
             Tasks::CopyPoliciesTask.new(context),
             Tasks::CopyPricingRulesTask.new(context),
             Tasks::CopyActiveDocsTask.new(context),
+            # Copy proxy must be the last task
+            # Proxy update is the mechanism to increase version of the proxy,
+            # Hence propagating (mapping rules, poicies, oidc, auth) update to
+            # latest proxy config, making available to gateway.
+            Tasks::CopyServiceProxyTask.new(context),
           ]
           tasks.each(&:call)
         end

--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -46,9 +46,13 @@ module ThreeScaleToolbox
             tasks << ThreeScaleToolbox::Tasks::DestroyMappingRulesTask.new(context)
             tasks << CreateMappingRulesStep.new(context)
             tasks << CreateActiveDocsStep.new(context)
-            tasks << UpdateServiceProxyStep.new(context)
             tasks << UpdateServiceOidcConfStep.new(context)
             tasks << UpdatePoliciesStep.new(context)
+            # Update proxy must be the last step
+            # Proxy update is the mechanism to increase version of the proxy,
+            # Hence propagating (mapping rules, poicies, oidc, auth) update to
+            # latest proxy config, making available to gateway.
+            tasks << UpdateServiceProxyStep.new(context)
 
             # run tasks
             tasks.each(&:call)

--- a/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
@@ -9,12 +9,15 @@ module ThreeScaleToolbox
           # Updates Proxy config
           def call
             # setting required attrs, operation is idempotent
-            proxy_settings = {}
+            proxy_settings = {
+              # Adding harmless attribute to avoid empty body
+              # update_proxy cannot be done with empty body
+              # and must be done to increase proxy version
+              service_id: service.id
+            }
 
             add_api_backend_settings(proxy_settings)
             add_security_proxy_settings(proxy_settings)
-
-            return unless proxy_settings.size.positive?
 
             res = service.update_proxy proxy_settings
             if (errors = res['errors'])

--- a/lib/3scale_toolbox/commands/update_command/update_service.rb
+++ b/lib/3scale_toolbox/commands/update_command/update_service.rb
@@ -41,7 +41,6 @@ module ThreeScaleToolbox
           tasks = []
           unless options[:'rules-only']
             tasks << Tasks::UpdateServiceSettingsTask.new(context.merge(target_name: system_name))
-            tasks << Tasks::CopyServiceProxyTask.new(context)
             tasks << Tasks::CopyMethodsTask.new(context)
             tasks << Tasks::CopyMetricsTask.new(context)
             tasks << Tasks::CopyApplicationPlansTask.new(context)
@@ -50,6 +49,11 @@ module ThreeScaleToolbox
             tasks << Tasks::CopyPricingRulesTask.new(context)
             tasks << Tasks::DeleteActiveDocsTask.new(context)
             tasks << Tasks::CopyActiveDocsTask.new(context)
+            # Copy proxy must be the last task
+            # Proxy update is the mechanism to increase version of the proxy,
+            # Hence propagating (mapping rules, poicies, oidc, auth) update to
+            # latest proxy config, making available to gateway.
+            tasks << Tasks::CopyServiceProxyTask.new(context)
           end
           tasks << Tasks::DestroyMappingRulesTask.new(context) if options[:force]
           tasks << Tasks::CopyMappingRulesTask.new(context)

--- a/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
       allow(api_spec).to receive(:schemes).and_return(schemes)
       allow(api_spec).to receive(:host).and_return(host)
       allow(api_spec).to receive(:security).and_return(security)
+      allow(service).to receive(:id).and_return(1000)
     end
 
     context 'no sec requirements' do
@@ -30,6 +31,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
         subject
       end
     end
+
     context 'apiKey sec requirement' do
       let(:key_name) { 'some_name' }
       let(:security) do


### PR DESCRIPTION
**Current situation**
When updating/creating proxy objects (the mapping rules, policies, oidc conf, auth conf, public base URLs), then this requires a second, not very intuitive, API call (i.e. proxy update) to update the proxy object and bump proxy config version.

If the proxy update call is not done, it can be very confusing because the mapping rules will appear in the integration page but they will not appear in the proxy config object. The same applies to mapping rules API calls. They changes will be available on mapping rules endpoints, but not available to the gateway because the proxy proxy config object has not changed.

This behavior is intended. In the API case you need to make several API calls and then bump the version. 

**Proposed changes**
This PR re-orders command tasks to make sure proxy update call is done *after* all updates are done. Proxy object should be updated with the latest changes made by the toolbox in `staging` environment.

Proxy object changes should not be applied to `production` environment. This task should be performed by a separate promoting command

