### PR TITLE
Crud metrics

### DIFF
--- a/3scale_toolbox.gemspec
+++ b/3scale_toolbox.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.4'
   spec.required_ruby_version = '>= 2.4'
 
-  spec.add_dependency '3scale-api', '~> 0.3.0'
+  spec.add_dependency '3scale-api', '~> 0.4.0'
   spec.add_dependency 'cri', '~> 2.15'
   spec.add_dependency 'json-schema', '~> 2.8'
 end

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ See the LICENSE and NOTICE files that should have been provided along with this 
    * [Copy a service](#copy-a-service)
    * [Update a service](#update-a-service)
    * [Import from CSV](#import-from-csv)
-   * [Import from OpenAPI definition](#import-openapi)
-   * [Export/Import Application Plan](#export-import-application-plan)
+   * [Import from OpenAPI definition](docs/openapi.md)
+   * [Export/Import Application Plan](docs/export-import-app-plan.md)
    * Create, Apply, List, Show, Delete [Application plan](docs/app-plan.md)
-   * [Remotes](#remotes)
+   * Create, Apply, List, Delete [Metric](docs/metric.md)
+   * Create, Apply, List, Delete [Method](docs/method.md)
+   * [Remotes](docs/remotes.md)
 * [Development](#development)
    * [Testing](#testing)
    * [Develop your own core command](#develop-core-command)
@@ -195,26 +197,6 @@ Example:
 ```shell
 3scale import csv --destination=https://provider_key@user-admin.3scale.net --file=examples/import_example.csv
 ```
-
-### Import OpenAPI
-
-Using an API definition format like OpenAPI, import to your 3scale API
-
-Currently, only OpenAPI __2.0__ specification (f.k.a. __swagger__) is supported.
-
-[Import from OpenAPI](docs/openapi.md)
-
-### Export Import Application Plan
-
-A single application plan can be exported/imported as `yaml` format.
-
-[Export/Import Application Plan](docs/export-import-app-plan.md)
-
-### Remotes
-
-Manage set of 3scale instances.
-
-[Howto](docs/remotes.md)
 
 ## Development
 

--- a/docs/app-plan.md
+++ b/docs/app-plan.md
@@ -23,7 +23,7 @@ NAME
 
 USAGE
     3scale application-plan create [opts] <remote>
-    <service> <plan_name>
+    <service> <plan-name>
 
 DESCRIPTION
     Create application plan

--- a/docs/method.md
+++ b/docs/method.md
@@ -20,7 +20,7 @@ NAME
 
 USAGE
     3scale methods create [opts] <remote>
-    <service> <method_name>
+    <service> <method-name>
 
 DESCRIPTION
     Create method

--- a/docs/method.md
+++ b/docs/method.md
@@ -1,0 +1,126 @@
+## Method
+
+* [Create new method](#create)
+* [Apply method](#apply)
+* [List methods](#list)
+* [Delete method](#delete)
+
+### Create
+
+* Creates a new method
+* Only method name is required. `system-name` can be override with optional parameter.
+* `service` positional argument is a service reference. It can be either service `id`, or service `system_name`. Toolbox will figure it out.
+* This is not idempotent command. If method with the same name already exists, command will fail.
+* Create a `disabled` method by `--disabled` flag. By default, it will be `enabled`.
+* Several other options can be set. Check `usage`
+
+```shell
+NAME
+    create - create method
+
+USAGE
+    3scale methods create [opts] <remote>
+    <service> <method_name>
+
+DESCRIPTION
+    Create method
+
+OPTIONS
+       --description=<value>      Method description
+       --disabled                 Disables this method in all application
+                                  plans
+    -t --system-name=<value>      Method system name
+
+OPTIONS FOR METHODS
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
+```
+
+### Apply
+
+* Update existing method. Create new one if it does not exist.
+* `service` positional argument is a service reference. It can be either service `id`, or service `system_name`. Toolbox will figure it out.
+* `method` positional argument is a method reference. It can be either method `id`, or method `system_name`. Toolbox will figure it out.
+* This is command is `idempotent`.
+* Update to `disabled` method by `--disabled` flag.
+* Update to `enabled` method by `--enabled` flag.
+* Several other options can be set. Check `usage`
+
+```shell
+NAME
+    apply - Update method
+
+USAGE
+    3scale methods apply [opts] <remote> <service>
+    <method>
+
+DESCRIPTION
+    Update (create if it does not exist) method
+
+OPTIONS
+       --description=<value>      Method description
+       --disabled                 Disables this method in all application
+                                  plans
+       --enabled                  Enables this method in all application
+                                  plans
+    -n --name=<value>             Method name
+
+OPTIONS FOR METHODS
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                   $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
+```
+
+### List
+
+```shell
+NAME
+    list - list methods
+
+USAGE
+    3scale methods list [opts] <remote> <service>
+
+DESCRIPTION
+    List methods
+
+OPTIONS FOR METHODS
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
+```
+
+### Delete
+
+```shell
+NAME
+    delete - delete method
+
+USAGE
+    3scale methods delete [opts] <remote>
+    <service> <method>
+
+DESCRIPTION
+    Delete method
+
+OPTIONS FOR METHODS
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
+```

--- a/docs/metric.md
+++ b/docs/metric.md
@@ -20,7 +20,7 @@ NAME
 
 USAGE
     3scale metrics create [opts] <remote>
-    <service> <metric_name>
+    <service> <metric-name>
 
 DESCRIPTION
     Create metric

--- a/docs/metric.md
+++ b/docs/metric.md
@@ -1,0 +1,128 @@
+## Metric
+
+* [Create new metric](#create)
+* [Apply metric](#apply)
+* [List metrics](#list)
+* [Delete metric](#delete)
+
+### Create
+
+* Creates a new metric
+* Only metric name is required. `system-name` can be override with optional parameter.
+* `service` positional argument is a service reference. It can be either service `id`, or service `system_name`. Toolbox will figure it out.
+* This is not idempotent command. If metric with the same name already exists, command will fail.
+* Create a `disabled` metric by `--disabled` flag. By default, it will be `enabled`.
+* Several other options can be set. Check `usage`
+
+```shell
+NAME
+    create - create metric
+
+USAGE
+    3scale metrics create [opts] <remote>
+    <service> <metric_name>
+
+DESCRIPTION
+    Create metric
+
+OPTIONS
+       --description=<value>      Metric description
+       --disabled                 Disables this metric in all application
+                                  plans
+    -t --system-name=<value>      Application plan system name
+       --unit=<value>             Metric unit. Default hit
+
+OPTIONS FOR METRICS
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
+```
+
+### Apply
+
+* Update existing metric. Create new one if it does not exist.
+* `service` positional argument is a service reference. It can be either service `id`, or service `system_name`. Toolbox will figure it out.
+* `metric` positional argument is a metric reference. It can be either metric `id`, or metric `system_name`. Toolbox will figure it out.
+* This is command is `idempotent`.
+* Update to `disabled` metric by `--disabled` flag.
+* Update to `enabled` metric by `--enabled` flag.
+* Several other options can be set. Check `usage`
+
+```shell
+NAME
+    apply - Update metric
+
+USAGE
+    3scale metrics apply [opts] <remote> <service>
+    <metric>
+
+DESCRIPTION
+    Update (create if it does not exist) metric
+
+OPTIONS
+       --description=<value>      Metric description
+       --disabled                 Disables this metric in all application
+                                  plans
+       --enabled                  Enables this metric in all application
+                                  plans
+    -n --name=<value>             Metric name
+       --unit=<value>             Metric unit. Default hit
+
+OPTIONS FOR METRICS
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
+```
+
+### List
+
+```shell
+NAME
+    list - list metrics
+
+USAGE
+    3scale metrics list [opts] <remote> <service>
+
+DESCRIPTION
+    List metrics
+
+OPTIONS FOR METRICS
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
+```
+
+### Delete
+
+```shell
+NAME
+    delete - delete metric
+
+USAGE
+    3scale metrics delete [opts] <remote>
+    <service> <metric>
+
+DESCRIPTION
+    Delete metric
+
+OPTIONS FOR METRICS
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
+```

--- a/lib/3scale_toolbox/base_command.rb
+++ b/lib/3scale_toolbox/base_command.rb
@@ -1,4 +1,3 @@
-
 module ThreeScaleToolbox
   module Command
     def self.included(base)

--- a/lib/3scale_toolbox/commands.rb
+++ b/lib/3scale_toolbox/commands.rb
@@ -5,6 +5,8 @@ require '3scale_toolbox/commands/import_command'
 require '3scale_toolbox/commands/update_command'
 require '3scale_toolbox/commands/remote_command'
 require '3scale_toolbox/commands/plans_command'
+require '3scale_toolbox/commands/metrics_command'
+require '3scale_toolbox/commands/methods_command'
 
 module ThreeScaleToolbox
   module Commands
@@ -15,6 +17,8 @@ module ThreeScaleToolbox
       ThreeScaleToolbox::Commands::UpdateCommand,
       ThreeScaleToolbox::Commands::RemoteCommand::RemoteCommand,
       ThreeScaleToolbox::Commands::PlansCommand,
+      ThreeScaleToolbox::Commands::MetricsCommand,
+      ThreeScaleToolbox::Commands::MethodsCommand,
     ].freeze
   end
 end

--- a/lib/3scale_toolbox/commands/copy_command/copy_service.rb
+++ b/lib/3scale_toolbox/commands/copy_command/copy_service.rb
@@ -26,7 +26,7 @@ module ThreeScaleToolbox
 
           source_service = Entities::Service.new(id: arguments[:service_id],
                                                  remote: threescale_client(source))
-          target_service = create_new_service(source_service.show_service, destination)
+          target_service = create_new_service(source_service.attrs, destination)
           puts "new service id #{target_service.id}"
           context = create_context(source_service, target_service)
           tasks = [

--- a/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_activedocs_step.rb
@@ -32,7 +32,7 @@ module ThreeScaleToolbox
           private
 
           def activedocs_system_name
-            @activedocs_system_name ||= service.show_service['system_name']
+            @activedocs_system_name ||= service.attrs['system_name']
           end
 
           def find_activedocs_id
@@ -53,7 +53,7 @@ module ThreeScaleToolbox
             # Other processing steps can work with original openapi spec
             Helper.hash_deep_dup(resource).tap do |activedocs|
               # public production base URL
-              URI(service.show_proxy.fetch('endpoint')).tap do |uri|
+              URI(service.proxy.fetch('endpoint')).tap do |uri|
                 activedocs['host'] = "#{uri.host}:#{uri.port}"
                 activedocs['schemes'] = [uri.scheme]
               end

--- a/lib/3scale_toolbox/commands/import_command/openapi/create_service_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_service_step.rb
@@ -9,22 +9,19 @@ module ThreeScaleToolbox
           # Creates service with a given system_name
           # If service already exists, update basic settings like name and description
           def call
-            # Create service and update context
-            self.service = Entities::Service.create(remote: threescale_client,
-                                                    service: service_settings,
-                                                    system_name: service_system_name)
-            puts "Created service id: #{service.id}, name: #{service_name}"
-          rescue ThreeScaleToolbox::Error => e
-            raise unless e.message =~ /"system_name"=>\["has already been taken"\]/
-
             # Update service and update context
             self.service = Entities::Service.find_by_system_name(remote: threescale_client,
                                                                  system_name: service_system_name)
-            # It should exist
-            raise ThreeScaleToolbox::Error, "Service with system_name: #{service_system_name}, should exist" if service.nil?
-
-            service.update_service(service_settings)
-            puts "Updated service id: #{service.id}, name: #{service_name}"
+            if service.nil?
+              # Create service and update context
+              self.service = Entities::Service.create(remote: threescale_client,
+                                                      service: service_settings,
+                                                      system_name: service_system_name)
+              puts "Created service id: #{service.id}, name: #{service_name}"
+            else
+              service.update(service_settings)
+              puts "Updated service id: #{service.id}, name: #{service_name}"
+            end
           end
 
           private

--- a/lib/3scale_toolbox/commands/methods_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command.rb
@@ -1,0 +1,28 @@
+require '3scale_toolbox/commands/methods_command/create_command'
+require '3scale_toolbox/commands/methods_command/list_command'
+require '3scale_toolbox/commands/methods_command/apply_command'
+require '3scale_toolbox/commands/methods_command/delete_command'
+
+module ThreeScaleToolbox
+  module Commands
+    module MethodsCommand
+      include ThreeScaleToolbox::Command
+      def self.command
+        Cri::Command.define do
+          name        'methods'
+          usage       'methods <sub-command> [options]'
+          summary     'methods super command'
+          description 'Methods commands'
+
+          run do |_opts, _args, cmd|
+            puts cmd.help
+          end
+        end
+      end
+      add_subcommand(Create::CreateSubcommand)
+      add_subcommand(List::ListSubcommand)
+      add_subcommand(Apply::ApplySubcommand)
+      add_subcommand(Delete::DeleteSubcommand)
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/methods_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command/apply_command.rb
@@ -1,0 +1,101 @@
+module ThreeScaleToolbox
+  module Commands
+    module MethodsCommand
+      module Apply
+        class ApplySubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          def self.command
+            Cri::Command.define do
+              name        'apply'
+              usage       'apply [opts] <remote> <service> <method>'
+              summary     'Update method'
+              description 'Update (create if it does not exist) method'
+
+              option      :n, :name, 'Method name', argument: :required
+              flag        nil, :disabled, 'Disables this method in all application plans'
+              flag        nil, :enabled, 'Enables this method in all application plans'
+              option      nil, :description, 'Method description', argument: :required
+              param       :remote
+              param       :service_ref
+              param       :method_ref
+
+              runner ApplySubcommand
+            end
+          end
+
+          def run
+            validate_option_params
+            hits = service.hits
+            method = Entities::Method.find(service: service, parent_id: hits.fetch('id'),
+                                           ref: method_ref)
+            if method.nil?
+              method = Entities::Method.create(service: service, parent_id: hits.fetch('id'),
+                                               attrs: create_method_attrs)
+            else
+              method.update(method_attrs) unless method_attrs.empty?
+            end
+
+            method.disable if option_disabled
+            method.enable if option_enabled
+
+            output_msg_array = ["Applied method id: #{method.id}"]
+            output_msg_array << 'Disabled' if option_disabled
+            output_msg_array << 'Enabled' if option_enabled
+            puts output_msg_array.join('; ')
+          end
+
+          private
+
+          def validate_option_params
+            raise ThreeScaleToolbox::Error, '--disabled and --enabled are mutually exclusive' \
+              if option_enabled && option_disabled
+          end
+
+          def create_method_attrs
+            method_attrs.merge('system_name' => method_ref,
+                               'friendly_name' => method_ref) { |_key, oldval, _newval| oldval }
+          end
+
+          def method_attrs
+            {
+              'friendly_name' => options[:name],
+              'description' => options[:description]
+            }.compact
+          end
+
+          def option_enabled
+            !options[:enabled].nil?
+          end
+
+          def option_disabled
+            !options[:disabled].nil?
+          end
+
+          def service
+            @service ||= find_service
+          end
+
+          def find_service
+            Entities::Service.find(remote: remote,
+                                   ref: service_ref).tap do |svc|
+              raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
+            end
+          end
+
+          def remote
+            @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def service_ref
+            arguments[:service_ref]
+          end
+
+          def method_ref
+            arguments[:method_ref]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/methods_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command/create_command.rb
@@ -1,0 +1,73 @@
+module ThreeScaleToolbox
+  module Commands
+    module MethodsCommand
+      module Create
+        class CreateSubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          def self.command
+            Cri::Command.define do
+              name        'create'
+              usage       'create [opts] <remote> <service> <method_name>'
+              summary     'create method'
+              description 'Create method'
+
+              option      :t, 'system-name', 'Method system name', argument: :required
+              flag        nil, :disabled, 'Disables this method in all application plans'
+              option      nil, :description, 'Method description', argument: :required
+              param       :remote
+              param       :service_ref
+              param       :method_name
+
+              runner CreateSubcommand
+            end
+          end
+
+          def run
+            hits = service.hits
+            method = ThreeScaleToolbox::Entities::Method.create(
+              service: service,
+              parent_id: hits.fetch('id'),
+              attrs: method_attrs
+            )
+            method.disable if option_disabled
+            puts "Created method id: #{method.id}. Disabled: #{option_disabled}"
+          end
+
+          private
+
+          def method_attrs
+            {
+              'system_name' => options[:'system-name'],
+              'friendly_name' => arguments[:method_name],
+              'description' => options[:description]
+            }.compact
+          end
+
+          def option_disabled
+            !options[:disabled].nil?
+          end
+
+          def service
+            @service ||= find_service
+          end
+
+          def find_service
+            Entities::Service.find(remote: remote,
+                                   ref: service_ref).tap do |svc|
+              raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
+            end
+          end
+
+          def remote
+            @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def service_ref
+            arguments[:service_ref]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/methods_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command/create_command.rb
@@ -8,7 +8,7 @@ module ThreeScaleToolbox
           def self.command
             Cri::Command.define do
               name        'create'
-              usage       'create [opts] <remote> <service> <method_name>'
+              usage       'create [opts] <remote> <service> <method-name>'
               summary     'create method'
               description 'Create method'
 

--- a/lib/3scale_toolbox/commands/methods_command/delete_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command/delete_command.rb
@@ -1,0 +1,67 @@
+module ThreeScaleToolbox
+  module Commands
+    module MethodsCommand
+      module Delete
+        class DeleteSubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          def self.command
+            Cri::Command.define do
+              name        'delete'
+              usage       'delete [opts] <remote> <service> <method>'
+              summary     'delete method'
+              description 'Delete method'
+
+              param       :remote
+              param       :service_ref
+              param       :method_ref
+
+              runner DeleteSubcommand
+            end
+          end
+
+          def run
+            method.delete
+            puts "Method id: #{method.id} deleted"
+          end
+
+          private
+
+          def service
+            @service ||= find_service
+          end
+
+          def method
+            @method ||= find_method
+          end
+
+          def find_service
+            Entities::Service.find(remote: remote,
+                                   ref: service_ref).tap do |svc|
+              raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
+            end
+          end
+
+          def find_method
+            hits = service.hits
+            Entities::Method.find(service: service, parent_id: hits.fetch('id'), ref: method_ref).tap do |p|
+              raise ThreeScaleToolbox::Error, "Method #{method_ref} does not exist" if p.nil?
+            end
+          end
+
+          def remote
+            @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def service_ref
+            arguments[:service_ref]
+          end
+
+          def method_ref
+            arguments[:method_ref]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/methods_command/list_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command/list_command.rb
@@ -1,0 +1,64 @@
+module ThreeScaleToolbox
+  module Commands
+    module MethodsCommand
+      module List
+        class ListSubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          FIELDS_TO_SHOW = %w[id friendly_name system_name description].freeze
+
+          def self.command
+            Cri::Command.define do
+              name        'list'
+              usage       'list [opts] <remote> <service>'
+              summary     'list methods'
+              description 'List methods'
+
+              param       :remote
+              param       :service_ref
+
+              runner ListSubcommand
+            end
+          end
+
+          def run
+            print_header
+            print_data
+          end
+
+          private
+
+          def print_header
+            puts FIELDS_TO_SHOW.map(&:upcase).join("\t")
+          end
+
+          def print_data
+            hits = service.hits
+            service.methods(hits.fetch('id')).each do |method|
+              puts FIELDS_TO_SHOW.map { |field| method.fetch(field, '(empty)') }.join("\t")
+            end
+          end
+
+          def service
+            @service ||= find_service
+          end
+
+          def find_service
+            Entities::Service.find(remote: remote,
+                                   ref: service_ref).tap do |svc|
+              raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
+            end
+          end
+
+          def remote
+            @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def service_ref
+            arguments[:service_ref]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/metrics_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command.rb
@@ -1,0 +1,28 @@
+require '3scale_toolbox/commands/metrics_command/create_command'
+require '3scale_toolbox/commands/metrics_command/list_command'
+require '3scale_toolbox/commands/metrics_command/apply_command'
+require '3scale_toolbox/commands/metrics_command/delete_command'
+
+module ThreeScaleToolbox
+  module Commands
+    module MetricsCommand
+      include ThreeScaleToolbox::Command
+      def self.command
+        Cri::Command.define do
+          name        'metrics'
+          usage       'metrics <sub-command> [options]'
+          summary     'metrics super command'
+          description 'Metrics commands'
+
+          run do |_opts, _args, cmd|
+            puts cmd.help
+          end
+        end
+      end
+      add_subcommand(Create::CreateSubcommand)
+      add_subcommand(List::ListSubcommand)
+      add_subcommand(Apply::ApplySubcommand)
+      add_subcommand(Delete::DeleteSubcommand)
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/metrics_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command/apply_command.rb
@@ -1,0 +1,102 @@
+module ThreeScaleToolbox
+  module Commands
+    module MetricsCommand
+      module Apply
+        class ApplySubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          def self.command
+            Cri::Command.define do
+              name        'apply'
+              usage       'apply [opts] <remote> <service> <metric>'
+              summary     'Update metric'
+              description 'Update (create if it does not exist) metric'
+
+              option      :n, :name, 'Metric name', argument: :required
+              flag        nil, :disabled, 'Disables this metric in all application plans'
+              flag        nil, :enabled, 'Enables this metric in all application plans'
+              option      nil, :unit, 'Metric unit. Default hit', argument: :required
+              option      nil, :description, 'Metric description', argument: :required
+              param       :remote
+              param       :service_ref
+              param       :metric_ref
+
+              runner ApplySubcommand
+            end
+          end
+
+          def run
+            validate_option_params
+            metric = Entities::Metric.find(service: service, ref: metric_ref)
+            if metric.nil?
+              metric = Entities::Metric.create(service: service,
+                                               attrs: create_metric_attrs)
+            else
+              metric.update(metric_attrs) unless metric_attrs.empty?
+            end
+
+            metric.disable if option_disabled
+            metric.enable if option_enabled
+
+            output_msg_array = ["Applied metric id: #{metric.id}"]
+            output_msg_array << 'Disabled' if option_disabled
+            output_msg_array << 'Enabled' if option_enabled
+            puts output_msg_array.join('; ')
+          end
+
+          private
+
+          def validate_option_params
+            raise ThreeScaleToolbox::Error, '--disabled and --enabled are mutually exclusive' \
+              if option_enabled && option_disabled
+          end
+
+          def create_metric_attrs
+            metric_attrs.merge('system_name' => metric_ref,
+                               'unit' => 'hit',
+                               'friendly_name' => metric_ref) { |_key, oldval, _newval| oldval }
+          end
+
+          def metric_attrs
+            {
+              'friendly_name' => options[:name],
+              'unit' => options[:unit],
+              'description' => options[:description]
+            }.compact
+          end
+
+          def option_enabled
+            !options[:enabled].nil?
+          end
+
+          def option_disabled
+            !options[:disabled].nil?
+          end
+
+          def service
+            @service ||= find_service
+          end
+
+          def find_service
+            Entities::Service.find(remote: remote,
+                                   ref: service_ref).tap do |svc|
+              raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
+            end
+          end
+
+          def remote
+            @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def service_ref
+            arguments[:service_ref]
+          end
+
+          def metric_ref
+            arguments[:metric_ref]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/metrics_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command/create_command.rb
@@ -8,7 +8,7 @@ module ThreeScaleToolbox
           def self.command
             Cri::Command.define do
               name        'create'
-              usage       'create [opts] <remote> <service> <metric_name>'
+              usage       'create [opts] <remote> <service> <metric-name>'
               summary     'create metric'
               description 'Create metric'
 

--- a/lib/3scale_toolbox/commands/metrics_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command/create_command.rb
@@ -1,0 +1,77 @@
+module ThreeScaleToolbox
+  module Commands
+    module MetricsCommand
+      module Create
+        class CreateSubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          def self.command
+            Cri::Command.define do
+              name        'create'
+              usage       'create [opts] <remote> <service> <metric_name>'
+              summary     'create metric'
+              description 'Create metric'
+
+              option      :t, 'system-name', 'Metric system name', argument: :required
+              flag        nil, :disabled, 'Disables this metric in all application plans'
+              option      nil, :unit, 'Metric unit. Default hit', argument: :required
+              option      nil, :description, 'Metric description', argument: :required
+              param       :remote
+              param       :service_ref
+              param       :metric_name
+
+              runner CreateSubcommand
+            end
+          end
+
+          def run
+            metric = ThreeScaleToolbox::Entities::Metric.create(
+              service: service,
+              attrs: metric_attrs
+            )
+            metric.disable if option_disabled
+            puts "Created metric id: #{metric.id}. Disabled: #{option_disabled}"
+          end
+
+          private
+
+          def metric_attrs
+            {
+              'system_name' => options[:'system-name'],
+              'unit' => unit,
+              'friendly_name' => arguments[:metric_name],
+              'description' => options[:description]
+            }.compact
+          end
+
+          def unit
+            options[:unit] || 'hit'
+          end
+
+          def option_disabled
+            !options[:disabled].nil?
+          end
+
+          def service
+            @service ||= find_service
+          end
+
+          def find_service
+            Entities::Service.find(remote: remote,
+                                   ref: service_ref).tap do |svc|
+              raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
+            end
+          end
+
+          def remote
+            @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def service_ref
+            arguments[:service_ref]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/metrics_command/delete_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command/delete_command.rb
@@ -1,0 +1,66 @@
+module ThreeScaleToolbox
+  module Commands
+    module MetricsCommand
+      module Delete
+        class DeleteSubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          def self.command
+            Cri::Command.define do
+              name        'delete'
+              usage       'delete [opts] <remote> <service> <metric>'
+              summary     'delete metric'
+              description 'Delete metric'
+
+              param       :remote
+              param       :service_ref
+              param       :metric_ref
+
+              runner DeleteSubcommand
+            end
+          end
+
+          def run
+            metric.delete
+            puts "Metric id: #{metric.id} deleted"
+          end
+
+          private
+
+          def service
+            @service ||= find_service
+          end
+
+          def metric
+            @metric ||= find_metric
+          end
+
+          def find_service
+            Entities::Service.find(remote: remote,
+                                   ref: service_ref).tap do |svc|
+              raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
+            end
+          end
+
+          def find_metric
+            Entities::Metric.find(service: service, ref: metric_ref).tap do |p|
+              raise ThreeScaleToolbox::Error, "Metric #{metric_ref} does not exist" if p.nil?
+            end
+          end
+
+          def remote
+            @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def service_ref
+            arguments[:service_ref]
+          end
+
+          def metric_ref
+            arguments[:metric_ref]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/metrics_command/list_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command/list_command.rb
@@ -1,0 +1,70 @@
+module ThreeScaleToolbox
+  module Commands
+    module MetricsCommand
+      module List
+        class ListSubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          FIELDS_TO_SHOW = %w[id friendly_name system_name unit description].freeze
+
+          def self.command
+            Cri::Command.define do
+              name        'list'
+              usage       'list [opts] <remote> <service>'
+              summary     'list metrics'
+              description 'List metrics'
+
+              param       :remote
+              param       :service_ref
+
+              runner ListSubcommand
+            end
+          end
+
+          def run
+            print_header
+            print_data
+          end
+
+          private
+
+          def print_header
+            puts FIELDS_TO_SHOW.map(&:upcase).join("\t")
+          end
+
+          def print_data
+            metrics.each do |metric|
+              puts FIELDS_TO_SHOW.map { |field| metric.fetch(field, '(empty)') }.join("\t")
+            end
+          end
+
+          def metrics
+            hits_id = service.hits['id']
+            ThreeScaleToolbox::Helper.array_difference(service.metrics, service.methods(hits_id)) do |metric, method|
+              ThreeScaleToolbox::Helper.compare_hashes(metric, method, %w[id])
+            end
+          end
+
+          def service
+            @service ||= find_service
+          end
+
+          def find_service
+            Entities::Service.find(remote: remote,
+                                   ref: service_ref).tap do |svc|
+              raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
+            end
+          end
+
+          def remote
+            @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def service_ref
+            arguments[:service_ref]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/plans_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/plans_command/create_command.rb
@@ -8,7 +8,7 @@ module ThreeScaleToolbox
           def self.command
             Cri::Command.define do
               name        'create'
-              usage       'create [opts] <remote> <service> <plan_name>'
+              usage       'create [opts] <remote> <service> <plan-name>'
               summary     'create application plan'
               description 'Create application plan'
 

--- a/lib/3scale_toolbox/commands/plans_command/export/read_app_plan_step.rb
+++ b/lib/3scale_toolbox/commands/plans_command/export/read_app_plan_step.rb
@@ -7,7 +7,7 @@ module ThreeScaleToolbox
           ##
           # Reads Application plan
           def call
-            result[:plan] = plan.show
+            result[:plan] = plan.attrs
           end
         end
       end

--- a/lib/3scale_toolbox/commands/plans_command/export/step.rb
+++ b/lib/3scale_toolbox/commands/plans_command/export/step.rb
@@ -50,7 +50,7 @@ module ThreeScaleToolbox
           end
 
           def service_methods
-            context[:service_methods] ||= service.methods
+            context[:service_methods] ||= service.methods(service_hits['id'])
           end
 
           def metric_info(elem, elem_name)
@@ -87,6 +87,10 @@ module ThreeScaleToolbox
 
           def find_method(id)
             service_methods.find { |method| method['id'] == id }
+          end
+
+          def service_hits
+            context[:service_hits] ||= service.hits
           end
         end
       end

--- a/lib/3scale_toolbox/commands/plans_command/import/import_plan_metrics_step.rb
+++ b/lib/3scale_toolbox/commands/plans_command/import/import_plan_metrics_step.rb
@@ -33,22 +33,16 @@ module ThreeScaleToolbox
           end
 
           def create_metric(metric_attrs)
-            metric = service.create_metric(metric_attrs)
-            if (errors = metric['errors'])
-              raise ThreeScaleToolbox::Error, "Metric has not been created. #{errors}"
-            end
-
-            puts "Created metric: #{metric['system_name']}"
+            metric = ThreeScaleToolbox::Entities::Metric.create(service: service,
+                                                                attrs: metric_attrs)
+            puts "Created metric: #{metric.attrs['system_name']}"
           end
 
           def create_method(method_attrs)
-            method = service.create_method(service_hits['id'], method_attrs)
-            if (errors = method['errors'])
-              raise ThreeScaleToolbox::Error, "Method has not been created. #{errors}" \
-
-            end
-
-            puts "Created method: #{method_attrs['system_name']}"
+            method = ThreeScaleToolbox::Entities::Method.create(service: service,
+                                                                parent_id: service_hits['id'],
+                                                                attrs: method_attrs)
+            puts "Created method: #{method.attrs['system_name']}"
           end
         end
       end

--- a/lib/3scale_toolbox/commands/plans_command/import/step.rb
+++ b/lib/3scale_toolbox/commands/plans_command/import/step.rb
@@ -74,11 +74,11 @@ module ThreeScaleToolbox
           end
 
           def service_hits
-            context[:service_hits] ||= find_service_hits
+            context[:service_hits] ||= service.hits
           end
 
           def service_methods
-            context[:service_methods] ||= service.methods
+            context[:service_methods] ||= service.methods(service_hits['id'])
           end
 
           def invalidate_service_methods
@@ -114,12 +114,6 @@ module ThreeScaleToolbox
           def find_plan
             Entities::ApplicationPlan.find(service: service, ref: plan_system_name).tap do |p|
               raise ThreeScaleToolbox::Error, "Application plan #{plan_system_name} does not exist" if p.nil?
-            end
-          end
-
-          def find_service_hits
-            find_metric_by_system_name('hits').tap do |hits_metric|
-              raise ThreeScaleToolbox::Error, 'missing hits metric' if hits_metric.nil?
             end
           end
         end

--- a/lib/3scale_toolbox/commands/plans_command/show_command.rb
+++ b/lib/3scale_toolbox/commands/plans_command/show_command.rb
@@ -43,7 +43,7 @@ module ThreeScaleToolbox
           end
 
           def plan_attrs
-            @plan_attrs ||= plan.show
+            @plan_attrs ||= plan.attrs
           end
 
           def plan

--- a/lib/3scale_toolbox/entities.rb
+++ b/lib/3scale_toolbox/entities.rb
@@ -1,2 +1,4 @@
 require '3scale_toolbox/entities/service'
 require '3scale_toolbox/entities/application_plan'
+require '3scale_toolbox/entities/metric'
+require '3scale_toolbox/entities/method'

--- a/lib/3scale_toolbox/entities/method.rb
+++ b/lib/3scale_toolbox/entities/method.rb
@@ -1,0 +1,80 @@
+module ThreeScaleToolbox
+  module Entities
+    class Method
+      class << self
+        def create(service:, parent_id:, attrs:)
+          method = service.remote.create_method service.id, parent_id, attrs
+          if (errors = method['errors'])
+            raise ThreeScaleToolbox::ThreeScaleApiError.new('Method has not been created', errors)
+
+          end
+
+          new(id: method.fetch('id'), parent_id: parent_id, service: service, attrs: method)
+        end
+
+        # ref can be system_name or method_id
+        def find(service:, parent_id:, ref:)
+          new(id: ref, parent_id: parent_id, service: service).tap(&:attrs)
+        rescue ThreeScale::API::HttpClient::NotFoundError
+          find_by_system_name(service: service, parent_id: parent_id, system_name: ref)
+        end
+
+        def find_by_system_name(service:, parent_id:, system_name:)
+          method = service.methods(parent_id).find { |m| m['system_name'] == system_name }
+          return if method.nil?
+
+          new(id: method.fetch('id'), parent_id: parent_id, service: service, attrs: method)
+        end
+      end
+
+      attr_reader :id, :parent_id, :service, :remote
+
+      def initialize(id:, parent_id:, service:, attrs: nil)
+        @id = id
+        @service = service
+        @parent_id = parent_id
+        @remote = service.remote
+        @attrs = attrs
+      end
+
+      def attrs
+        @attrs ||= method_attrs
+      end
+
+      def disable
+        Metric.new(id: id, service: service).disable
+      end
+
+      def enable
+        Metric.new(id: id, service: service).enable
+      end
+
+      def update(m_attrs)
+        new_attrs = remote.update_method(service.id, parent_id, id, m_attrs)
+        if (errors = new_attrs['errors'])
+          raise ThreeScaleToolbox::ThreeScaleApiError.new('Method has not been updated', errors)
+        end
+
+        # update current attrs
+        @attrs = new_attrs
+
+        new_attrs
+      end
+
+      def delete
+        remote.delete_method service.id, parent_id, id
+      end
+
+      private
+
+      def method_attrs
+        method = remote.show_method service.id, parent_id, id
+        if (errors = method['errors'])
+          raise ThreeScaleToolbox::ThreeScaleApiError.new('Method not read', errors)
+        end
+
+        method
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/entities/metric.rb
+++ b/lib/3scale_toolbox/entities/metric.rb
@@ -1,0 +1,113 @@
+module ThreeScaleToolbox
+  module Entities
+    class Metric
+      class << self
+        def create(service:, attrs:)
+          metric = service.remote.create_metric service.id, attrs
+          if (errors = metric['errors'])
+            raise ThreeScaleToolbox::ThreeScaleApiError.new('Metric has not been created', errors)
+          end
+
+          new(id: metric.fetch('id'), service: service, attrs: metric)
+        end
+
+        # ref can be system_name or metric_id
+        def find(service:, ref:)
+          new(id: ref, service: service).tap(&:attrs)
+        rescue ThreeScale::API::HttpClient::NotFoundError
+          find_by_system_name(service: service, system_name: ref)
+        end
+
+        def find_by_system_name(service:, system_name:)
+          metric = service.metrics.find { |m| m['system_name'] == system_name }
+          return if metric.nil?
+
+          new(id: metric.fetch('id'), service: service, attrs: metric)
+        end
+      end
+
+      attr_reader :id, :service, :remote
+
+      def initialize(id:, service:, attrs: nil)
+        @id = id
+        @service = service
+        @remote = service.remote
+        @attrs = attrs
+      end
+
+      def attrs
+        @attrs ||= metric_attrs
+      end
+
+      def disable
+        # For each plan, get limits for the current metric
+        # if already disabled -> NOOP
+        # if non zero eternity limit exist, update
+        # if non eternity limit exist, create
+        service_plans.each do |plan|
+          eternity_limit = plan_eternity_limit(plan)
+          if eternity_limit.nil?
+            plan.create_limit(id, zero_eternity_limit_attrs)
+          elsif !eternity_limit.fetch('value').zero?
+            plan.update_limit(id, eternity_limit.fetch('id'), zero_eternity_limit_attrs)
+          end
+        end
+      end
+
+      def enable
+        service_plans.each do |plan|
+          limit = plan_zero_eternity_limit(plan)
+          plan.delete_limit(id, limit.fetch('id')) unless limit.nil?
+        end
+      end
+
+      def update(new_metric_attrs)
+        new_attrs = remote.update_metric(service.id, id, new_metric_attrs)
+        if (errors = new_attrs['errors'])
+          raise ThreeScaleToolbox::ThreeScaleApiError.new('Metric has not been updated', errors)
+        end
+
+        # update current attrs
+        @attrs = new_attrs
+
+        new_attrs
+      end
+
+      def delete
+        remote.delete_metric service.id, id
+      end
+
+      private
+
+      def metric_attrs
+        metric = remote.show_metric service.id, id
+        if (errors = metric['errors'])
+          raise ThreeScaleToolbox::ThreeScaleApiError.new('Metric attrs not read', errors)
+        end
+
+        metric
+      end
+
+      def plan_zero_eternity_limit(plan)
+        # only one limit for eternity period is allowed per (plan_id, metric_id)
+        plan.metric_limits(id).find { |limit| limit > zero_eternity_limit_attrs }
+      end
+
+      def plan_eternity_limit(plan)
+        # only one limit for eternity period is allowed per (plan_id, metric_id)
+        plan.metric_limits(id).find { |limit| limit['period'] == 'eternity' }
+      end
+
+      def service_plans
+        service.plans.map do |plan_attrs|
+          ThreeScaleToolbox::Entities::ApplicationPlan.new(id: plan_attrs.fetch('id'),
+                                                           service: service)
+        end
+      end
+
+      def zero_eternity_limit_attrs
+        { 'period' => 'eternity', 'value' => 0 }
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/error.rb
+++ b/lib/3scale_toolbox/error.rb
@@ -5,4 +5,17 @@ module ThreeScaleToolbox
 
   class InvalidUrlError < Error
   end
+
+  class ThreeScaleApiError < Error
+    attr_reader :apierrors
+
+    def initialize(msg = '', apierrors = {})
+      @apierrors = apierrors
+      super(msg)
+    end
+
+    def message
+      "#{super}. Errors: #{apierrors}"
+    end
+  end
 end

--- a/lib/3scale_toolbox/tasks/copy_activedocs_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_activedocs_task.rb
@@ -6,7 +6,7 @@ module ThreeScaleToolbox
       def call
         puts 'copying all service ActiveDocs'
 
-        target_activedocs = source.list_activedocs.map do |source_activedoc|
+        target_activedocs = source.activedocs.map do |source_activedoc|
           source_activedoc.clone.tap do |target_activedoc|
             target_activedoc.delete('id')
             target_activedoc['service_id'] = target.id

--- a/lib/3scale_toolbox/tasks/copy_methods_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_methods_task.rb
@@ -4,15 +4,18 @@ module ThreeScaleToolbox
       include CopyTask
 
       def call
-        source_methods = source.methods
-        target_methods = target.methods
-        target_hits_metric_id = target.hits['id']
-        puts "original service hits metric #{source.hits['id']} has #{source_methods.size} methods"
-        puts "target service hits metric #{target_hits_metric_id} has #{target_methods.size} methods"
+        source_hits_id = source.hits['id']
+        target_hits_id = target.hits['id']
+        source_methods = source.methods source_hits_id
+        target_methods = target.methods target_hits_id
+        puts "original service hits metric #{source_hits_id} has #{source_methods.size} methods"
+        puts "target service hits metric #{target_hits_id} has #{target_methods.size} methods"
         missing = missing_methods(source_methods, target_methods).each do |method|
-          filtered_method = ThreeScaleToolbox::Helper.filter_params(%w[friendly_name system_name],
-                                                                    method)
-          target.create_method(target_hits_metric_id, filtered_method)
+          Entities::Method.create(
+            service: target,
+            parent_id: target_hits_id,
+            attrs: ThreeScaleToolbox::Helper.filter_params(%w[friendly_name system_name], method)
+          )
         end
         puts "created #{missing.size} missing methods on target service"
       end

--- a/lib/3scale_toolbox/tasks/copy_metrics_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_metrics_task.rb
@@ -14,7 +14,7 @@ module ThreeScaleToolbox
 
         missing.each do |metric|
           metric.delete('links')
-          target.create_metric(metric)
+          Entities::Metric.create(service: target, attrs: metric)
         end
 
         puts "created #{missing.size} metrics on the target service"

--- a/lib/3scale_toolbox/tasks/copy_service_proxy_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_service_proxy_task.rb
@@ -4,7 +4,7 @@ module ThreeScaleToolbox
       include CopyTask
 
       def call
-        target.update_proxy source.show_proxy
+        target.update_proxy source.proxy
         puts "updated proxy of #{target.id} to match the original"
       end
     end

--- a/lib/3scale_toolbox/tasks/delete_activedocs_task.rb
+++ b/lib/3scale_toolbox/tasks/delete_activedocs_task.rb
@@ -9,7 +9,7 @@ module ThreeScaleToolbox
 
       def call
         puts 'deleting all target service ActiveDocs'
-        target.list_activedocs.each do |activedoc|
+        target.activedocs.each do |activedoc|
           target.remote.delete_activedocs(activedoc['id'])
         end
       end

--- a/lib/3scale_toolbox/tasks/update_service_settings_task.rb
+++ b/lib/3scale_toolbox/tasks/update_service_settings_task.rb
@@ -10,7 +10,7 @@ module ThreeScaleToolbox
       end
 
       def call
-        source_obj = source.show_service
+        source_obj = source.attrs
         svc_obj = update_service target_service_params(source_obj)
         if (errors = svc_obj['errors'])
           raise ThreeScaleToolbox::Error, "Service has not been saved. Errors: #{errors}" \
@@ -22,7 +22,7 @@ module ThreeScaleToolbox
       private
 
       def update_service(service)
-        svc_obj = target.update_service service
+        svc_obj = target.update service
 
         # Source and target remotes might not allow same set of deployment options
         # Invalid deployment option check
@@ -30,7 +30,7 @@ module ThreeScaleToolbox
         if (errors = svc_obj['errors']) &&
            ThreeScaleToolbox::Helper.service_invalid_deployment_option?(errors)
           service.delete('deployment_option')
-          svc_obj = target.update_service(service)
+          svc_obj = target.update service
         end
 
         svc_obj

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -40,15 +40,16 @@ module Helpers
       3.times.each do
         method = { 'system_name' => Helpers.random_lowercase_name,
                    'friendly_name' => Helpers.random_lowercase_name }
-        service.create_method(hits_id, method)
+        ThreeScaleToolbox::Entities::Method.create(service: service, parent_id: hits_id,
+                                                   attrs: method)
       end
     end
 
     def create_metrics
       4.times.each do
         name = Helpers.random_lowercase_name
-        metric = { 'name' => name, 'system_name' => name, 'unit' => '1' }
-        service.create_metric(metric)
+        metric = { 'friendly_name' => name, 'system_name' => name, 'unit' => '1' }
+        ThreeScaleToolbox::Entities::Metric.create(service: service, attrs: metric)
       end
     end
 

--- a/spec/integration/copy_service_spec.rb
+++ b/spec/integration/copy_service_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.shared_context :copy_service_stubbed_external_http_client do
   let(:external_source_service) { { 'service' => { 'id' => source_service_id } } }
   let(:external_target_service) { { 'service' => { 'id' => target_service_id } } }
@@ -166,13 +164,13 @@ RSpec.shared_context :copy_service_stubbed_external_http_client do
     ##
     # service creation calls
     expect(external_source_client).to receive(:post).with('/admin/api/services', anything).and_return(external_source_service)
-    expect(external_source_client).to receive(:post).exactly(3).times.with('/admin/api/services/1/metrics/1/methods', anything)
-    expect(external_source_client).to receive(:post).exactly(4).times.with('/admin/api/services/1/metrics', anything)
+    expect(external_source_client).to receive(:post).exactly(3).times.with('/admin/api/services/1/metrics/1/methods', anything).and_return('id' => 11)
+    expect(external_source_client).to receive(:post).exactly(4).times.with('/admin/api/services/1/metrics', anything).and_return('id' => 1)
     expect(external_source_client).to receive(:post).exactly(2).times.with('/admin/api/services/1/application_plans', anything).and_return(external_app_plan_01)
     expect(external_source_client).to receive(:post).exactly(8).times.with('/admin/api/application_plans/1/metrics/1/limits', anything).and_return({})
     expect(external_source_client).to receive(:post).exactly(2).times.with('/admin/api/services/1/proxy/mapping_rules', anything)
     expect(external_source_client).to receive(:post).with('/admin/api/application_plans/1/metrics/1/pricing_rules', anything).exactly(2).times.and_return({})
-    expect(external_source_client).to receive(:put).with('/admin/api/services/1/proxy/policies', anything)
+    expect(external_source_client).to receive(:put).with('/admin/api/services/1/proxy/policies', anything).and_return({})
     # activedocs
     allow(external_source_client).to receive(:get).with('/admin/api/active_docs').and_return(external_source_activedocs)
     allow(external_target_client).to receive(:get).with('/admin/api/active_docs').and_return(external_target_activedocs)
@@ -182,7 +180,7 @@ RSpec.shared_context :copy_service_stubbed_external_http_client do
 end
 
 RSpec.shared_context :copy_service_stubbed_internal_http_client do
-  let(:internal_http_client) { double('internal_http_client') }
+  let(:internal_http_client) { instance_double('ThreeScale::API::HttpClient', 'internal_http_client') }
   let(:http_client_class) { class_double('ThreeScale::API::HttpClient').as_stubbed_const }
 
   let(:internal_source_service) { { 'service' => { 'id' => source_service_id } } }
@@ -210,11 +208,12 @@ RSpec.shared_context :copy_service_stubbed_internal_http_client do
       ]
     }
   end
+  let(:internal_source_method) do
+    { 'method' => { 'id' => '11', 'system_name' => 'method_11' } }
+  end
   let(:internal_source_methods) do
     {
-      'methods' => [
-        { 'method' => { 'id' => '11', 'system_name' => 'method_11' } }
-      ]
+      'methods' => [internal_source_method]
     }
   end
   let(:internal_target_methods) { { 'methods' => [] } }
@@ -328,7 +327,7 @@ RSpec.shared_context :copy_service_stubbed_internal_http_client do
     # get source proxy settings
     expect(internal_http_client).to receive(:get).with('/admin/api/services/1/proxy').and_return(internal_source_proxy_service)
     # update target proxy settings
-    expect(internal_http_client).to receive(:patch).with('/admin/api/services/100/proxy', anything)
+    expect(internal_http_client).to receive(:patch).with('/admin/api/services/100/proxy', anything).and_return(internal_source_proxy_service)
     # get source metrics
     expect(internal_http_client).to receive(:get).with('/admin/api/services/1/metrics').at_least(:once).and_return(internal_source_metrics)
     # get target metrics
@@ -338,7 +337,7 @@ RSpec.shared_context :copy_service_stubbed_internal_http_client do
     # get target methods
     expect(internal_http_client).to receive(:get).with('/admin/api/services/100/metrics/100/methods').and_return(internal_target_methods)
     # create target method
-    expect(internal_http_client).to receive(:post).with('/admin/api/services/100/metrics/100/methods', anything)
+    expect(internal_http_client).to receive(:post).with('/admin/api/services/100/metrics/100/methods', anything).and_return(internal_source_method)
     # get source app plans
     expect(internal_http_client).to receive(:get).with('/admin/api/services/1/application_plans').at_least(:once).and_return(internal_source_app_plans)
     # get target app plans
@@ -382,8 +381,8 @@ RSpec.shared_context :copy_service_stubbed_api3scale_clients do
   let(:target_system_name) { 'stubbed_system_name' }
   let(:source_service_id) { '1' }
   let(:target_service_id) { '100' }
-  let(:external_source_client) { double('external_source_client') }
-  let(:external_target_client) { double('external_target_client') }
+  let(:external_source_client) { instance_double('ThreeScale::API::HttpClient', 'external_source_client') }
+  let(:external_target_client) { instance_double('ThreeScale::API::HttpClient', 'external_target_client') }
   let(:client_url) do
     endpoint_uri = URI(endpoint)
     endpoint_uri.user = provider_key

--- a/spec/integration/import_openapi_basepath_spec.rb
+++ b/spec/integration/import_openapi_basepath_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.shared_context :import_oas_basepath_stubbed do
   include_context :oas_common_mocked_context
 

--- a/spec/integration/import_openapi_oidc_spec.rb
+++ b/spec/integration/import_openapi_oidc_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.shared_context :import_oas_oidc_stubbed do
   include_context :oas_common_mocked_context
 

--- a/spec/integration/import_openapi_spec.rb
+++ b/spec/integration/import_openapi_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.shared_context :import_oas_basic_stubbed do
   include_context :oas_common_mocked_context
 
@@ -81,7 +79,7 @@ RSpec.describe 'OpenAPI import basic test' do
   let(:command_line_str) do
     "import openapi -t #{system_name} -d #{destination_url} #{oas_resource_path}"
   end
-  let(:service_active_docs) { service.list_activedocs }
+  let(:service_active_docs) { service.activedocs }
   let(:backend_version) { '1' }
   let(:expected_methods) do
     [
@@ -114,7 +112,8 @@ RSpec.describe 'OpenAPI import basic test' do
     expect(expected_methods.size).to be > 0
     # test Set(service.methods) includes Set(expected_methods)
     # with a custom identity method for methods
-    expect(expected_methods).to be_subset_of(service.methods).comparing_keys(method_keys)
+    hits_id = service.hits['id']
+    expect(expected_methods).to be_subset_of(service.methods(hits_id)).comparing_keys(method_keys)
 
     # mapping rules are created
     expect(expected_mapping_rules.size).to be > 0

--- a/spec/integration/remote_add_spec.rb
+++ b/spec/integration/remote_add_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Commands::RemoteCommand::RemoteAddSubcommand do
   include_context :resources
   include_context :temp_dir

--- a/spec/integration/remote_list_spec.rb
+++ b/spec/integration/remote_list_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Commands::RemoteCommand::RemoteListSubcommand do
   include_context :temp_dir
   include_context :resources

--- a/spec/integration/remote_remove_spec.rb
+++ b/spec/integration/remote_remove_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Commands::RemoteCommand::RemoteRemoveSubcommand do
   include_context :resources
   include_context :temp_dir

--- a/spec/integration/remote_rename_spec.rb
+++ b/spec/integration/remote_rename_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Commands::RemoteCommand::RemoteRenameSubcommand do
   include_context :resources
   include_context :temp_dir

--- a/spec/integration/update_all_service_spec.rb
+++ b/spec/integration/update_all_service_spec.rb
@@ -1,16 +1,13 @@
-require '3scale_toolbox'
-
 RSpec.shared_context :update_all_stubbed_external_http_client do
   let(:external_source_service) { { 'service' => { 'id' => source_service_id } } }
   let(:external_target_service) { { 'service' => { 'id' => target_service_id } } }
   let(:external_proxy) { { 'proxy' => { 'api_backend' => 'https://example.com:443' } } }
-  let(:external_methods) do
+  let(:external_method) do
     {
-      'methods' => [
-        { 'method' => { 'id' => '11', 'system_name' => 'method_11', 'metric_id' => '1' } }
-      ]
+      'method' => { 'id' => '11', 'system_name' => 'method_11', 'metric_id' => '1' }
     }
   end
+  let(:external_methods) { { 'methods' => [external_method] } }
   let(:external_metrics) do
     {
       'metrics' => [
@@ -167,10 +164,10 @@ RSpec.shared_context :update_all_stubbed_external_http_client do
     # service creation calls
     expect(external_source_client).to receive(:post).with('/admin/api/services', anything).and_return(external_source_service)
     expect(external_target_client).to receive(:post).with('/admin/api/services', anything).and_return(external_target_service)
-    expect(external_source_client).to receive(:post).exactly(3).times.with('/admin/api/services/1/metrics/1/methods', anything)
-    expect(external_target_client).to receive(:post).exactly(3).times.with('/admin/api/services/100/metrics/1/methods', anything)
-    expect(external_source_client).to receive(:post).exactly(4).times.with('/admin/api/services/1/metrics', anything)
-    expect(external_target_client).to receive(:post).exactly(4).times.with('/admin/api/services/100/metrics', anything)
+    expect(external_source_client).to receive(:post).exactly(3).times.with('/admin/api/services/1/metrics/1/methods', anything).and_return(external_method)
+    expect(external_target_client).to receive(:post).exactly(3).times.with('/admin/api/services/100/metrics/1/methods', anything).and_return(external_method)
+    expect(external_source_client).to receive(:post).exactly(4).times.with('/admin/api/services/1/metrics', anything).and_return('id' => 11)
+    expect(external_target_client).to receive(:post).exactly(4).times.with('/admin/api/services/100/metrics', anything).and_return('id' => 1)
     expect(external_source_client).to receive(:post).exactly(2).times.with('/admin/api/services/1/application_plans', anything).and_return(external_app_plan_01)
     expect(external_target_client).to receive(:post).exactly(2).times.with('/admin/api/services/100/application_plans', anything).and_return(external_app_plan_01)
     expect(external_source_client).to receive(:post).exactly(8).times.with('/admin/api/application_plans/1/metrics/1/limits', anything).and_return({})
@@ -191,7 +188,7 @@ RSpec.shared_context :update_all_stubbed_external_http_client do
 end
 
 RSpec.shared_context :update_all_stubbed_internal_http_client do
-  let(:internal_http_client) { double('internal_http_client') }
+  let(:internal_http_client) { instance_double('ThreeScale::API::HttpClient', 'internal_http_client') }
   let(:http_client_class) { class_double('ThreeScale::API::HttpClient').as_stubbed_const }
 
   let(:internal_source_service) { { 'service' => { 'id' => source_service_id } } }
@@ -219,11 +216,12 @@ RSpec.shared_context :update_all_stubbed_internal_http_client do
       ]
     }
   end
+  let(:internal_source_method) do
+    { 'method' => { 'id' => '11', 'system_name' => 'method_11' } }
+  end
   let(:internal_source_methods) do
     {
-      'methods' => [
-        { 'method' => { 'id' => '11', 'system_name' => 'method_11' } }
-      ]
+      'methods' => [internal_source_method]
     }
   end
   let(:internal_target_methods) { { 'methods' => [] } }
@@ -337,7 +335,7 @@ RSpec.shared_context :update_all_stubbed_internal_http_client do
     # get source proxy settings
     expect(internal_http_client).to receive(:get).with('/admin/api/services/1/proxy').and_return(internal_source_proxy_service)
     # update target proxy settings
-    expect(internal_http_client).to receive(:patch).with('/admin/api/services/100/proxy', anything)
+    expect(internal_http_client).to receive(:patch).with('/admin/api/services/100/proxy', anything).and_return({})
     # get source metrics
     expect(internal_http_client).to receive(:get).with('/admin/api/services/1/metrics').at_least(:once).and_return(internal_source_metrics)
     # get target metrics
@@ -347,7 +345,7 @@ RSpec.shared_context :update_all_stubbed_internal_http_client do
     # get target methods
     expect(internal_http_client).to receive(:get).with('/admin/api/services/100/metrics/100/methods').and_return(internal_target_methods)
     # create target method
-    expect(internal_http_client).to receive(:post).with('/admin/api/services/100/metrics/100/methods', anything)
+    expect(internal_http_client).to receive(:post).with('/admin/api/services/100/metrics/100/methods', anything).and_return(internal_source_method)
     # get source app plans
     expect(internal_http_client).to receive(:get).with('/admin/api/services/1/application_plans').at_least(:once).and_return(internal_source_app_plans)
     # get target app plans
@@ -391,8 +389,8 @@ RSpec.shared_context :update_all_stubbed_api3scale_clients do
   let(:target_system_name) { 'stubbed_system_name' }
   let(:source_service_id) { '1' }
   let(:target_service_id) { '100' }
-  let(:external_source_client) { double('external_source_client') }
-  let(:external_target_client) { double('external_target_client') }
+  let(:external_source_client) { instance_double('ThreeScale::API::HttpClient', 'external_source_client') }
+  let(:external_target_client) { instance_double('ThreeScale::API::HttpClient', 'external_target_client') }
   let(:client_url) do
     endpoint_uri = URI(endpoint)
     endpoint_uri.user = provider_key

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,10 +12,14 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 
+require 'erb'
+require 'tmpdir'
+require 'pathname'
 require 'dotenv'
 Dotenv.load
 require 'webmock/rspec'
 WebMock.disable_net_connect!
+require '3scale_toolbox'
 require_relative 'helpers'
 require_relative 'shared_contexts'
 require_relative 'shared_examples'

--- a/spec/unit/3scale_client_factory_spec.rb
+++ b/spec/unit/3scale_client_factory_spec.rb
@@ -1,14 +1,12 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::ThreeScaleClientFactory do
-  let(:remotes) { double('remotes') }
+  let(:remotes) { instance_double('ThreeScaleToolbox::Remotes', 'remotes') }
   let(:threescale_api) { class_double('ThreeScale::API').as_stubbed_const }
   let(:endpoint) { 'https://example.com' }
   let(:authentication) { '123456789' }
   let(:verify_ssl) { true }
   let(:api_info) { { endpoint: endpoint, provider_key: authentication, verify_ssl: verify_ssl } }
   let(:remote_info) { { endpoint: endpoint, authentication: authentication } }
-  let(:client) { double('client') }
+  let(:client) { instance_double('ThreeScale::API::Client', 'client') }
   let(:verbose) { false }
   let(:remote_str) do
     u = URI(endpoint)
@@ -40,7 +38,7 @@ RSpec.describe ThreeScaleToolbox::ThreeScaleClientFactory do
 
       it 'proxy client is returned' do
         proxy_logger = class_double('ThreeScaleToolbox::ProxyLogger').as_stubbed_const
-        proxied_client = double('proxied_client')
+        proxied_client = instance_double('ThreeScaleToolbox::ProxyLogger', 'proxied_client')
         expect(proxy_logger).to receive(:new).with(client).and_return(proxied_client)
         expect(subject).to eq(proxied_client)
       end

--- a/spec/unit/3scale_toolbox_spec.rb
+++ b/spec/unit/3scale_toolbox_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox do
   include_context :temp_dir
   include_context :plugin

--- a/spec/unit/command_hierarchy_spec.rb
+++ b/spec/unit/command_hierarchy_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe 'Plugin Command Hierarchy' do
   include_context :random_name
 

--- a/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_activedocs_step_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActive
       'basePath' => '/v1',
     }
   end
-  let(:api_spec) { double('api_spec') }
-  let(:service) { double('service') }
-  let(:threescale_client) { double('threescale_client') }
+  let(:api_spec) { instance_double('ThreeScaleToolbox::ImportCommand::OpenAPI::ThreeScaleApiSpec') }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
+  let(:threescale_client) { instance_double('ThreeScale::API::Client', 'threescale_client') }
   let(:published) { true }
   let(:skip_openapi_validation) { false }
   let(:oidc_issuer_endpoint) { 'https://client_id:secret@sso.oidcissuer.com/oidc' }
@@ -56,8 +56,8 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActive
       allow(api_spec).to receive(:security).and_return(security)
       allow(api_spec).to receive(:public_base_path).and_return(new_public_base_path)
       allow(service).to receive(:id).and_return(service_id)
-      allow(service).to receive(:show_service).and_return(service_attrs)
-      allow(service).to receive(:show_proxy).and_return(service_proxy)
+      allow(service).to receive(:attrs).and_return(service_attrs)
+      allow(service).to receive(:proxy).and_return(service_proxy)
     end
 
     context 'creates activedocs' do

--- a/spec/unit/commands/import_command/openapi/create_mapping_rules_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_mapping_rules_step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMappingRulesStep do
-  let(:service) { double('service') }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
   let(:op0) { double('op0') }
   let(:op1) { double('op1') }
   let(:operations) { [op0, op1] }

--- a/spec/unit/commands/import_command/openapi/create_service_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_service_step_spec.rb
@@ -1,10 +1,9 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateServiceStep do
-  let(:api_spec) { double('api_spec') }
+  let(:api_spec) { instance_double('ThreeScaleToolbox::ImportCommand::OpenAPI::ThreeScaleApiSpec') }
+  let(:service_class) { class_double('ThreeScaleToolbox::Entities::Service').as_stubbed_const }
   let(:service_id) { '100' }
-  let(:service) { ThreeScaleToolbox::Entities::Service.new(id: service_id, remote: nil) }
-  let(:threescale_client) { double('threescale_client') }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
+  let(:threescale_client) { instance_double('ThreeScale::API::Client', 'threescale_client') }
   let(:title) { 'Some Title' }
   let(:description) { 'Some Description' }
   let(:openapi_context) do
@@ -13,6 +12,13 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateServic
       api_spec: api_spec,
       threescale_client: threescale_client,
       target_system_name: 'some_system_name'
+    }
+  end
+  let(:expected_settings) do
+    {
+      'name' => title,
+      'description' => description,
+      'backend_version' => 'oidc'
     }
   end
 
@@ -26,44 +32,31 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateServic
     end
 
     context 'when service exists' do
-      let(:existing_services) do
-        [
-          { 'id' => service_id, 'system_name' => openapi_context[:target_system_name] }
-        ]
-      end
-
-      let(:expected_settings) do
-        {
-          'name' => title,
-          'description' => description,
-          'backend_version' => 'oidc'
-        }
-      end
 
       before :example do
-        expect(ThreeScaleToolbox::Entities::Service).to receive(:create)
-          .with(hash_including(remote: threescale_client))
-          .and_raise(ThreeScaleToolbox::Error, 'Service has not been saved. Errors: {"system_name"=>["has already been taken"]}')
-        expect(threescale_client).to receive(:list_services).and_return(existing_services)
-        expect(ThreeScaleToolbox::Entities::Service).to receive(:new)
-          .with(hash_including(remote: threescale_client))
+        expect(service_class).to receive(:find_by_system_name)
+          .with(remote: threescale_client, system_name: openapi_context[:target_system_name])
           .and_return(service)
+        expect(service).to receive(:id).and_return(service_id)
       end
 
       it 'service is updated' do
-        expect(service).to receive(:update_service).with(expected_settings)
+        expect(service).to receive(:update).with(expected_settings)
         expect { subject }.to output(/Updated service id: #{service_id}/).to_stdout
       end
     end
 
     context 'when service does not exist' do
       before :example do
-        expect(ThreeScaleToolbox::Entities::Service).to receive(:create)
-          .with(hash_including(remote: threescale_client))
-          .and_return(service)
+        expect(service_class).to receive(:find_by_system_name)
+          .with(remote: threescale_client, system_name: openapi_context[:target_system_name])
+          .and_return(nil)
       end
 
       it 'service is created' do
+        expect(service_class).to receive(:create).with(hash_including(service: expected_settings))
+                                                 .and_return(service)
+        expect(service).to receive(:id).and_return(service_id)
         expect { subject }.to output(/Created service id: #{service_id}/).to_stdout
       end
     end

--- a/spec/unit/commands/import_command/openapi/threescale_api_spec_spec.rb
+++ b/spec/unit/commands/import_command/openapi/threescale_api_spec_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::ThreeScaleApiSpec do
   let(:title) { 'Some Title' }
   let(:description) { 'Some Description' }

--- a/spec/unit/commands/import_command/openapi/update_policies_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_policies_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdatePoliciesStep do
-  let(:api_spec) { double('api_spec') }
-  let(:service) { double('service') }
+  let(:api_spec) { instance_double('ThreeScaleToolbox::ImportCommand::OpenAPI::ThreeScaleApiSpec') }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
   let(:default_credentials_userkey) { '12345' }
   let(:override_private_basepath) { nil }
   let(:available_policies) do

--- a/spec/unit/commands/import_command/openapi/update_service_oidc_conf_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_service_oidc_conf_spec.rb
@@ -11,8 +11,8 @@ RSpec.shared_examples 'oidc is updated with required flow' do
 end
 
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServiceOidcConfStep do
-  let(:api_spec) { double('api_spec') }
-  let(:service) { double('service') }
+  let(:api_spec) { instance_double('ThreeScaleToolbox::ImportCommand::OpenAPI::ThreeScaleApiSpec') }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
   let(:openapi_context) do
     {
       target: service,

--- a/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServiceProxyStep do
-  let(:api_spec) { double('api_spec') }
-  let(:service) { double('service') }
+  let(:api_spec) { instance_double('ThreeScaleToolbox::ImportCommand::OpenAPI::ThreeScaleApiSpec') }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
   let(:schemes) { [] }
   let(:host) { 'example.com' }
   let(:oidc_issuer_endpoint) { 'https://sso.example.com' }

--- a/spec/unit/commands/import_command/openapi_spec.rb
+++ b/spec/unit/commands/import_command/openapi_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::OpenAPISubcommand do
   include_context :temp_dir
   include_context :resources
@@ -12,7 +10,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::OpenAPISubco
     let(:oas_resource) { File.join(resources_path, 'valid_swagger.yaml') }
 
     context '#run' do
-      let(:api_spec) { double('api_spec') }
+      let(:api_spec) { instance_double('ThreeScaleToolbox::ImportCommand::OpenAPI::ThreeScaleApiSpec') }
 
       before :each do
         threescale_api_spec_stub = class_double(ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::ThreeScaleApiSpec).as_stubbed_const

--- a/spec/unit/commands/methods_command/apply_command_spec.rb
+++ b/spec/unit/commands/methods_command/apply_command_spec.rb
@@ -1,0 +1,138 @@
+RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Apply::ApplySubcommand do
+  let(:arguments) do
+    {
+      service_ref: 'someservice', remote: 'https://destination_key@destination.example.com',
+      method_ref: 'somemethod'
+    }
+  end
+  let(:options) { {} }
+  let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+  let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
+  let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
+  let(:method_class) { class_double(ThreeScaleToolbox::Entities::Method).as_stubbed_const }
+  let(:method) { instance_double(ThreeScaleToolbox::Entities::Method) }
+  let(:hits_id) { 1 }
+  let(:hits) { { 'id' => hits_id } }
+  subject { described_class.new(options, arguments, nil) }
+
+  context '#run' do
+    context 'when --disabled and --enabled set' do
+      let(:options) { { disabled: true, enabled: true } }
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error, /mutually exclusive/)
+      end
+    end
+
+    context 'valid params' do
+      before :example do
+        expect(service_class).to receive(:find).and_return(service)
+        expect(subject).to receive(:threescale_client).and_return(remote)
+      end
+
+      context 'when service not found' do
+        let(:service) { nil }
+
+        it 'error raised' do
+          expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                                /Service someservice does not exist/)
+        end
+      end
+
+      context 'when method not found' do
+        let(:method_attrs) do
+          {
+            'friendly_name' => arguments[:method_ref],
+            'system_name' => arguments[:method_ref]
+          }
+        end
+
+        before :example do
+          expect(service).to receive(:hits).and_return(hits)
+          expect(method_class).to receive(:find).with(service: service,
+                                                      parent_id: hits_id,
+                                                      ref: arguments[:method_ref])
+                                                .and_return(nil)
+          expect(method).to receive(:id).and_return(1)
+        end
+
+        it 'method created' do
+          expect(method_class).to receive(:create).with(service: service,
+                                                        parent_id: hits_id,
+                                                        attrs: method_attrs)
+                                                  .and_return(method)
+          expect { subject.run }.to output(/Applied method id: 1/).to_stdout
+        end
+
+        context 'when name in options' do
+          let(:options) { { name: 'new name' } }
+          let(:method_attrs) do
+            {
+              'friendly_name' => options[:name],
+              'system_name' => arguments[:method_ref]
+            }
+          end
+
+          it 'friendly_name overriden' do
+            expect(method_class).to receive(:create).with(service: service,
+                                                          parent_id: hits_id,
+                                                          attrs: method_attrs)
+                                                    .and_return(method)
+            expect { subject.run }.to output(/Applied method id: 1/).to_stdout
+          end
+        end
+      end
+
+      context 'when method found' do
+        before :example do
+          expect(service).to receive(:hits).and_return(hits)
+          expect(method_class).to receive(:find).with(service: service,
+                                                      parent_id: hits_id,
+                                                      ref: arguments[:method_ref])
+                                                .and_return(method)
+          expect(method).to receive(:id).and_return(1)
+        end
+
+        context 'with no options' do
+          let(:options) { {} }
+
+          it 'method not updated' do
+            expect { subject.run }.to output(/Applied method id: 1/).to_stdout
+          end
+        end
+
+        context 'with options' do
+          let(:options) { { name: 'some name', description: 'some descr' } }
+          let(:method_attrs) do
+            {
+              'friendly_name' => options[:name],
+              'description' => options[:description]
+            }
+          end
+
+          it 'method updated' do
+            expect(method).to receive(:update).with(method_attrs)
+            expect { subject.run }.to output(/Applied method id: 1/).to_stdout
+          end
+        end
+
+        context 'with disable option' do
+          let(:options) { { disabled: true } }
+
+          it 'method disabled' do
+            expect(method).to receive(:disable)
+            expect { subject.run }.to output(/Applied method id: 1/).to_stdout
+          end
+        end
+
+        context 'with enabled option' do
+          let(:options) { { enabled: true } }
+
+          it 'method disabled' do
+            expect(method).to receive(:enable)
+            expect { subject.run }.to output(/Applied method id: 1/).to_stdout
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands/methods_command/create_command_spec.rb
+++ b/spec/unit/commands/methods_command/create_command_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Create::CreateSubcommand do
+  let(:arguments) do
+    {
+      service_ref: 'someservice', remote: 'https://destination_key@destination.example.com',
+      method_name: 'some method'
+    }
+  end
+  let(:options) { {} }
+  let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+  let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
+  let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
+  let(:method_class) { class_double(ThreeScaleToolbox::Entities::Method).as_stubbed_const }
+  let(:method) { instance_double(ThreeScaleToolbox::Entities::Method) }
+  let(:hits_id) { 1 }
+  let(:hits) { { 'id' => hits_id } }
+  let(:expected_basic_attrs) { { 'friendly_name' => arguments[:method_name] } }
+  subject { described_class.new(options, arguments, nil) }
+
+  context '#run' do
+    before :example do
+      expect(service_class).to receive(:find).and_return(service)
+      expect(subject).to receive(:threescale_client).and_return(remote)
+    end
+
+    context 'when service not found' do
+      let(:service) { nil }
+
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                              /Service someservice does not exist/)
+      end
+    end
+
+    context 'when method is created' do
+      let(:expected_attrs) { expected_basic_attrs }
+      before :example do
+        expect(service).to receive(:hits).and_return(hits)
+        expect(method_class).to receive(:create).with(service: service,
+                                                      parent_id: hits_id,
+                                                      attrs: expected_attrs)
+                                                .and_return(method)
+        expect(method).to receive(:id).and_return('1')
+      end
+
+      it do
+        expect { subject.run }.to output(/Created method id: 1/).to_stdout
+      end
+
+      context 'with disable option' do
+        let(:options) { { disabled: true } }
+
+        it 'method disabled' do
+          expect(method).to receive(:disable)
+          expect { subject.run }.to output(/Created method id: 1/).to_stdout
+        end
+      end
+
+      context 'with other options' do
+        let(:options) do
+          {
+            'system-name': 'a',
+            description: 'b'
+          }
+        end
+        let(:expected_attrs) do
+          expected_basic_attrs.merge('system_name' => 'a', 'description' => 'b')
+        end
+
+        it 'method created with expected params' do
+          expect { subject.run }.to output(/Created method id: 1/).to_stdout
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands/methods_command/delete_command_spec.rb
+++ b/spec/unit/commands/methods_command/delete_command_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Delete::DeleteSubcommand do
+  let(:arguments) do
+    {
+      method_ref: 'somemethod', service_ref: 'someservice',
+      remote: 'https://destination_key@destination.example.com'
+    }
+  end
+  let(:options) { {} }
+  let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+  let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
+  let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
+  let(:method_class) { class_double(ThreeScaleToolbox::Entities::Method).as_stubbed_const }
+  let(:method) { instance_double(ThreeScaleToolbox::Entities::Method) }
+  let(:hits_id) { 1 }
+  let(:hits) { { 'id' => hits_id } }
+  subject { described_class.new(options, arguments, nil) }
+
+  context '#run' do
+    before :example do
+      expect(service_class).to receive(:find).and_return(service)
+      expect(subject).to receive(:threescale_client).and_return(remote)
+    end
+
+    context 'when service not found' do
+      let(:service) { nil }
+
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                              /Service someservice does not exist/)
+      end
+    end
+
+    context 'when method not found' do
+      before :example do
+        expect(service).to receive(:hits).and_return(hits)
+        expect(method_class).to receive(:find).with(service: service,
+                                                    parent_id: hits_id,
+                                                    ref: arguments[:method_ref]).and_return(nil)
+      end
+
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                              /Method somemethod does not exist/)
+      end
+    end
+
+    context 'when method found' do
+      before :example do
+        expect(service).to receive(:hits).and_return(hits)
+        expect(method_class).to receive(:find).with(service: service,
+                                                    parent_id: hits_id,
+                                                    ref: arguments[:method_ref])
+                                              .and_return(method)
+        expect(method).to receive(:id).and_return('1')
+      end
+
+      it do
+        expect(method).to receive(:delete)
+        expect { subject.run }.to output(/Method id: 1 deleted/).to_stdout
+      end
+    end
+  end
+end

--- a/spec/unit/commands/methods_command/list_command_spec.rb
+++ b/spec/unit/commands/methods_command/list_command_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::List::ListSubcommand do
+  let(:arguments) do
+    {
+      service_ref: 'someservice', remote: 'https://destination_key@destination.example.com'
+    }
+  end
+  let(:options) { {} }
+  let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
+  let(:hits_id) { 1 }
+  let(:hits) { { 'id' => hits_id, 'friendly_name' => 'hits' } }
+  subject { described_class.new(options, arguments, nil) }
+
+  context '#run' do
+    before :example do
+      expect(service_class).to receive(:find).and_return(service)
+      expect(subject).to receive(:threescale_client).and_return(remote)
+    end
+
+    context 'when service not found' do
+      let(:service) { nil }
+
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                              /Service someservice does not exist/)
+      end
+    end
+
+    context 'when metric list is returned' do
+      let(:method_0) { { 'id' => '3', 'friendly_name' => 'method 0' } }
+      let(:method_1) { { 'id' => '4', 'friendly_name' => 'method 1' } }
+      let(:methods) { [method_0, method_1] }
+
+      before :example do
+        expect(service).to receive(:hits).and_return(hits)
+        expect(service).to receive(:methods).with(hits_id).and_return(methods)
+      end
+
+      it 'method_0 in the list' do
+        expect { subject.run }.to output(/method 0/).to_stdout
+      end
+
+      it 'method_1 in the list' do
+        expect { subject.run }.to output(/method 1/).to_stdout
+      end
+    end
+  end
+end

--- a/spec/unit/commands/metrics_command/apply_command_spec.rb
+++ b/spec/unit/commands/metrics_command/apply_command_spec.rb
@@ -1,0 +1,138 @@
+RSpec.describe ThreeScaleToolbox::Commands::MetricsCommand::Apply::ApplySubcommand do
+  let(:arguments) do
+    {
+      service_ref: 'someservice', remote: 'https://destination_key@destination.example.com',
+      metric_ref: 'somemetric'
+    }
+  end
+  let(:options) { {} }
+  let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
+  let(:metric_class) { class_double(ThreeScaleToolbox::Entities::Metric).as_stubbed_const }
+  let(:metric) { instance_double(ThreeScaleToolbox::Entities::Metric) }
+  subject { described_class.new(options, arguments, nil) }
+
+  context '#run' do
+    context 'when --disabled and --enabled set' do
+      let(:options) { { disabled: true, enabled: true } }
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error, /mutually exclusive/)
+      end
+    end
+
+    context 'valid params' do
+      before :example do
+        expect(service_class).to receive(:find).and_return(service)
+        expect(subject).to receive(:threescale_client).and_return(remote)
+      end
+
+      context 'when service not found' do
+        let(:service) { nil }
+
+        it 'error raised' do
+          expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                                /Service someservice does not exist/)
+        end
+      end
+
+      context 'when metric not found' do
+        let(:metric_attrs) do
+          {
+            'friendly_name' => arguments[:metric_ref],
+            'unit' => 'hit',
+            'system_name' => arguments[:metric_ref]
+          }
+        end
+
+        before :example do
+          expect(metric_class).to receive(:find).and_return(nil)
+          expect(metric).to receive(:id).and_return(1)
+        end
+
+        it 'metric created' do
+          expect(metric_class).to receive(:create).with(service: service, attrs: metric_attrs)
+                                                  .and_return(metric)
+          expect { subject.run }.to output(/Applied metric id: 1/).to_stdout
+        end
+
+        context 'when name in options' do
+          let(:options) { { name: 'new name' } }
+          let(:metric_attrs) do
+            {
+              'friendly_name' => options[:name],
+              'unit' => 'hit',
+              'system_name' => arguments[:metric_ref]
+            }
+          end
+
+          it 'friendly_name overriden' do
+            expect(metric_class).to receive(:create).with(service: service, attrs: metric_attrs)
+                                                    .and_return(metric)
+            expect { subject.run }.to output(/Applied metric id: 1/).to_stdout
+          end
+        end
+
+        context 'when unit in options' do
+          let(:options) { { unit: 'new unit' } }
+          let(:metric_attrs) do
+            {
+              'friendly_name' => arguments[:metric_ref],
+              'unit' => 'new unit',
+              'system_name' => arguments[:metric_ref]
+            }
+          end
+
+          it 'unit overriden' do
+            expect(metric_class).to receive(:create).with(service: service, attrs: metric_attrs)
+                                                    .and_return(metric)
+            expect { subject.run }.to output(/Applied metric id: 1/).to_stdout
+          end
+        end
+      end
+
+      context 'when metric found' do
+        before :example do
+          expect(metric_class).to receive(:find).and_return(metric)
+          expect(metric).to receive(:id).and_return(1)
+        end
+
+        context 'with no options' do
+          let(:options) { {} }
+
+          it 'metric not updated' do
+            expect { subject.run }.to output(/Applied metric id: 1/).to_stdout
+          end
+        end
+
+        context 'with options' do
+          let(:options) { { unit: 'bla', description: 'some descr' } }
+          let(:metric_attrs) { Hash[options.map { |k, v| [k.to_s, v] }] }
+
+          it 'metric updated' do
+            expect(metric).to receive(:update).with(metric_attrs)
+            expect { subject.run }.to output(/Applied metric id: 1/).to_stdout
+          end
+        end
+
+        context 'with disable option' do
+          let(:options) { { disabled: true } }
+
+          it 'metric disabled' do
+            expect(metric).to receive(:disable)
+            expect { subject.run }.to output(/Applied metric id: 1/).to_stdout
+          end
+        end
+
+        context 'with enabled option' do
+          let(:options) { { enabled: true } }
+
+          it 'metric disabled' do
+            expect(metric).to receive(:enable)
+            expect { subject.run }.to output(/Applied metric id: 1/).to_stdout
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands/metrics_command/create_command_spec.rb
+++ b/spec/unit/commands/metrics_command/create_command_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe ThreeScaleToolbox::Commands::MetricsCommand::Create::CreateSubcommand do
+  let(:arguments) do
+    {
+      service_ref: 'someservice', remote: 'https://destination_key@destination.example.com',
+      metric_name: 'some metric'
+    }
+  end
+  let(:options) { {} }
+  let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+  let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
+  let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
+  let(:metric_class) { class_double(ThreeScaleToolbox::Entities::Metric).as_stubbed_const }
+  let(:metric) { instance_double(ThreeScaleToolbox::Entities::Metric) }
+  let(:expected_basic_attrs) do
+    {
+      'friendly_name' => arguments[:metric_name],
+      'unit' => 'hit'
+    }
+  end
+  subject { described_class.new(options, arguments, nil) }
+
+  context '#run' do
+    before :example do
+      expect(service_class).to receive(:find).and_return(service)
+      expect(subject).to receive(:threescale_client).and_return(remote)
+    end
+
+    context 'when service not found' do
+      let(:service) { nil }
+
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                              /Service someservice does not exist/)
+      end
+    end
+
+    context 'when metric is created' do
+      let(:expected_attrs) { expected_basic_attrs }
+      before :example do
+        expect(metric_class).to receive(:create).with(service: service, attrs: expected_attrs)
+                                                .and_return(metric)
+        expect(metric).to receive(:id).and_return('1')
+      end
+
+      it do
+        expect { subject.run }.to output(/Created metric id: 1/).to_stdout
+      end
+
+      context 'with disable option' do
+        let(:options) { { disabled: true } }
+
+        it 'metric disabled' do
+          expect(metric).to receive(:disable)
+          expect { subject.run }.to output(/Created metric id: 1/).to_stdout
+        end
+      end
+
+      context 'with other options' do
+        let(:options) do
+          {
+            'unit': 'myunit',
+            'system-name': 'a',
+            description: 'c'
+          }
+        end
+        let(:expected_attrs) do
+          expected_basic_attrs.merge('system_name' => 'a', 'unit' => 'myunit',
+                                     'description' => 'c')
+        end
+
+        it 'metric created with expected params' do
+          expect { subject.run }.to output(/Created metric id: 1/).to_stdout
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands/metrics_command/delete_command_spec.rb
+++ b/spec/unit/commands/metrics_command/delete_command_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe ThreeScaleToolbox::Commands::MetricsCommand::Delete::DeleteSubcommand do
+  let(:arguments) do
+    {
+      metric_ref: 'somemetric', service_ref: 'someservice',
+      remote: 'https://destination_key@destination.example.com'
+    }
+  end
+  let(:options) { {} }
+  let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+  let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
+  let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
+  let(:metric_class) { class_double(ThreeScaleToolbox::Entities::Metric).as_stubbed_const }
+  let(:metric) { instance_double(ThreeScaleToolbox::Entities::Metric) }
+  subject { described_class.new(options, arguments, nil) }
+
+  context '#run' do
+    before :example do
+      expect(service_class).to receive(:find).and_return(service)
+      expect(subject).to receive(:threescale_client).and_return(remote)
+    end
+
+    context 'when service not found' do
+      let(:service) { nil }
+
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                              /Service someservice does not exist/)
+      end
+    end
+
+    context 'when metric not found' do
+      before :example do
+        expect(metric_class).to receive(:find).with(service: service,
+                                                    ref: arguments[:metric_ref]).and_return(nil)
+      end
+
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                              /Metric somemetric does not exist/)
+      end
+    end
+
+    context 'when metric found' do
+      before :example do
+        expect(metric_class).to receive(:find).and_return(metric)
+        expect(metric).to receive(:id).and_return('1')
+      end
+
+      it do
+        expect(metric).to receive(:delete)
+        expect { subject.run }.to output(/Metric id: 1 deleted/).to_stdout
+      end
+    end
+  end
+end

--- a/spec/unit/commands/metrics_command/list_command_spec.rb
+++ b/spec/unit/commands/metrics_command/list_command_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe ThreeScaleToolbox::Commands::MetricsCommand::List::ListSubcommand do
+  let(:arguments) do
+    {
+      service_ref: 'someservice', remote: 'https://destination_key@destination.example.com'
+    }
+  end
+  let(:options) { {} }
+  let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
+  subject { described_class.new(options, arguments, nil) }
+
+  context '#run' do
+    before :example do
+      expect(service_class).to receive(:find).and_return(service)
+      expect(subject).to receive(:threescale_client).and_return(remote)
+    end
+
+    context 'when service not found' do
+      let(:service) { nil }
+
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                              /Service someservice does not exist/)
+      end
+    end
+
+    context 'when metric list is returned' do
+      let(:hits_metric) { { 'id' => '0', 'friendly_name' => 'hits' } }
+      let(:metric_1) { { 'id' => '1', 'friendly_name' => 'metric 1' } }
+      let(:metric_2) { { 'id' => '2', 'friendly_name' => 'metric 2' } }
+      let(:method_0) { { 'id' => '3', 'friendly_name' => 'method 0' } }
+      let(:method_1) { { 'id' => '4', 'friendly_name' => 'method 1' } }
+      let(:methods) { [method_0, method_1] }
+      # metrics include methods
+      let(:metrics) { [hits_metric, metric_1, metric_2] + methods }
+
+      before :example do
+        expect(service).to receive(:hits).and_return(hits_metric)
+        expect(service).to receive(:metrics).and_return(metrics)
+        expect(service).to receive(:methods).with(hits_metric['id']).and_return(methods)
+      end
+
+      it 'method_0 not in the list' do
+        expect { subject.run }.not_to output(/method 0/).to_stdout
+      end
+
+      it 'method_1 not in the list' do
+        expect { subject.run }.not_to output(/method 1/).to_stdout
+      end
+
+      it 'hits metric in the list' do
+        expect { subject.run }.to output(/hits/).to_stdout
+      end
+
+      it 'metric_1 in the list' do
+        expect { subject.run }.to output(/metric 1/).to_stdout
+      end
+
+      it 'metric_2 in the list' do
+        expect { subject.run }.to output(/metric 2/).to_stdout
+      end
+    end
+  end
+end

--- a/spec/unit/commands/plans_command/apply_command_spec.rb
+++ b/spec/unit/commands/plans_command/apply_command_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Apply::ApplySubcommand
   end
   let(:options) { {} }
   let(:basic_plan_attrs) { { 'name' => 'someplan' } }
-  let(:remote) { instance_double('ThreeScale::API') }
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
   let(:plan_class) { class_double(ThreeScaleToolbox::Entities::ApplicationPlan).as_stubbed_const }

--- a/spec/unit/commands/plans_command/create_command_spec.rb
+++ b/spec/unit/commands/plans_command/create_command_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Create::CreateSubcomma
   end
   let(:options) { {} }
   let(:basic_plan_attrs) { { 'name' => 'someplan' } }
-  let(:remote) { instance_double('ThreeScale::API') }
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
   let(:plan_class) { class_double(ThreeScaleToolbox::Entities::ApplicationPlan).as_stubbed_const }
@@ -92,7 +92,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Create::CreateSubcomma
         end
         let(:plan_attrs) { basic_plan_attrs.merge(expected_params) }
 
-        it 'plan disabled' do
+        it 'plan created with expected params' do
           expect { subject.run }.to output(/Created application plan id: 1/).to_stdout
         end
       end

--- a/spec/unit/commands/plans_command/delete_command_spec.rb
+++ b/spec/unit/commands/plans_command/delete_command_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Delete::DeleteSubcomma
     }
   end
   let(:options) {}
-  let(:remote) { instance_double('ThreeScale::API') }
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
   let(:plan_class) { class_double(ThreeScaleToolbox::Entities::ApplicationPlan).as_stubbed_const }

--- a/spec/unit/commands/plans_command/export/read_plan_limits_step_spec.rb
+++ b/spec/unit/commands/plans_command/export/read_plan_limits_step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Export::ReadPlanLimitsStep do
-  let(:threescale_client) { double('threescale_client') }
+  let(:threescale_client) { instance_double('ThreeScale::API::Client', 'threescale_client') }
   let(:service_system_name) { 'myservice' }
   let(:service_class) { class_double('ThreeScaleToolbox::Entities::Service').as_stubbed_const }
   let(:service_info) { { remote: threescale_client, ref: service_system_name } }
@@ -55,10 +55,13 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Export::ReadPlanLimits
           { 'id' => '01', 'name' => 'Metric 01', 'system_name' => 'metric_01' }
         ]
       end
+      let(:hits_id) { '1' }
+      let(:hits_metric) { { 'id' => hits_id, 'unit' => '1' } }
 
       before :example do
         expect(service).to receive(:metrics).and_return(service_metrics)
-        expect(service).to receive(:methods).and_return(service_methods)
+        expect(service).to receive(:hits).and_return(hits_metric)
+        expect(service).to receive(:methods).with(hits_id).and_return(service_methods)
       end
 
       it 'limit addded' do

--- a/spec/unit/commands/plans_command/export/read_plan_pricing_rules_step_spec.rb
+++ b/spec/unit/commands/plans_command/export/read_plan_pricing_rules_step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Export::ReadPlanPricingRulesStep do
-  let(:threescale_client) { double('threescale_client') }
+  let(:threescale_client) { instance_double('ThreeScale::API::Client', 'threescale_client') }
   let(:service_system_name) { 'myservice' }
   let(:service_class) { class_double('ThreeScaleToolbox::Entities::Service').as_stubbed_const }
   let(:service_info) { { remote: threescale_client, ref: service_system_name } }
@@ -49,14 +49,17 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Export::ReadPlanPricin
           { 'id' => '02', 'name' => 'Method 01', 'system_name' => 'method_01' }
         ]
       end
+      let(:hits_metric) { { 'id' => '100', 'system_name' => 'hits' } }
       # service metrics include service methods
       let(:service_metrics) do
         service_methods + [
-          { 'id' => '01', 'name' => 'Metric 01', 'system_name' => 'metric_01' }
+          { 'id' => '01', 'name' => 'Metric 01', 'system_name' => 'metric_01' },
+          hits_metric
         ]
       end
 
       before :example do
+        expect(service).to receive(:hits).and_return(hits_metric)
         expect(service).to receive(:metrics).and_return(service_metrics)
         expect(service).to receive(:methods).and_return(service_methods)
       end

--- a/spec/unit/commands/plans_command/import/create_or_update_app_plan_step_spec.rb
+++ b/spec/unit/commands/plans_command/import/create_or_update_app_plan_step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::CreateOrUpdateAppPlanStep do
-  let(:threescale_client) { double('threescale_client') }
+  let(:threescale_client) { instance_double('ThreeScale::API::Client', 'threescale_client') }
   let(:service_system_name) { 'myservice' }
   let(:plan_system_name) { 'myplan' }
   let(:service_class) { class_double('ThreeScaleToolbox::Entities::Service').as_stubbed_const }

--- a/spec/unit/commands/plans_command/import/import_plan_features_step_spec.rb
+++ b/spec/unit/commands/plans_command/import/import_plan_features_step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::ImportPlanFeaturesStep do
-  let(:threescale_client) { double('threescale_client') }
+  let(:threescale_client) { instance_double('ThreeScale::API::Client', 'threescale_client') }
   let(:service_system_name) { 'myservice' }
   let(:plan_system_name) { 'myplan' }
   let(:service_class) { class_double('ThreeScaleToolbox::Entities::Service').as_stubbed_const }

--- a/spec/unit/commands/plans_command/import/import_plan_limits_step_spec.rb
+++ b/spec/unit/commands/plans_command/import/import_plan_limits_step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::ImportMetricLimitsStep do
-  let(:threescale_client) { double('threescale_client') }
+  let(:threescale_client) { instance_double('ThreeScale::API::Client', 'threescale_client') }
   let(:service_system_name) { 'myservice' }
   let(:plan_system_name) { 'myplan' }
   let(:service_class) { class_double('ThreeScaleToolbox::Entities::Service').as_stubbed_const }

--- a/spec/unit/commands/plans_command/import/import_plan_metrics_step_spec.rb
+++ b/spec/unit/commands/plans_command/import/import_plan_metrics_step_spec.rb
@@ -1,14 +1,19 @@
 RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::ImportMetricsStep do
-  let(:threescale_client) { double('threescale_client') }
+  let(:threescale_client) { instance_double('ThreeScale::API::Client', 'threescale_client') }
   let(:service_system_name) { 'myservice' }
   let(:service_class) { class_double('ThreeScaleToolbox::Entities::Service').as_stubbed_const }
   let(:service_info) { { remote: threescale_client, ref: service_system_name } }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
+  let(:metric_class) { class_double('ThreeScaleToolbox::Entities::Metric').as_stubbed_const }
+  let(:metric) { instance_double('ThreeScaleToolbox::Entities::Metric') }
+  let(:method_class) { class_double('ThreeScaleToolbox::Entities::Method').as_stubbed_const }
+  let(:method) { instance_double('ThreeScaleToolbox::Entities::Method') }
   let(:plan_system_name) { 'myplan' }
   let(:service_methods) { [] }
   let(:service_metrics) { [] }
   let(:resource_methods) { [] }
   let(:resource_metrics) { [] }
+  let(:hits_metric) { { 'id' => 1 } }
   let(:artifacts_resource) do
     {
       'methods' => resource_methods,
@@ -31,6 +36,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::ImportMetricsS
                                              .and_return(service)
       allow(service).to receive(:methods).and_return(service_methods)
       allow(service).to receive(:metrics).and_return(service_metrics)
+      allow(service).to receive(:hits).and_return(hits_metric)
     end
 
     context 'no missing metric or methods' do
@@ -44,17 +50,10 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::ImportMetricsS
       let(:resource_metrics) { [resource_metric] }
 
       it 'then metric is created' do
-        expect(service).to receive(:create_metric).with(hash_including(resource_metric))
-                                                  .and_return('id' => 1000)
+        expect(metric_class).to receive(:create).with(hash_including(attrs: resource_metric))
+                                                .and_return(metric)
+        expect(metric).to receive(:attrs).and_return(resource_metric)
         expect { subject.call }.to output(/Created metric/).to_stdout
-      end
-
-      context 'and create_metric returns error' do
-        it 'then error raised' do
-          expect(service).to receive(:create_metric).and_return('errors' => 'some error')
-          expect { subject.call }.to raise_error(ThreeScaleToolbox::Error,
-                                                 /Metric has not been created/)
-        end
       end
     end
 
@@ -66,17 +65,11 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::ImportMetricsS
       let(:service_metrics) { [hits_metric] }
 
       it 'then method is created' do
-        expect(service).to receive(:create_method).with(hits_id, hash_including(resource_method))
-                                                  .and_return('id' => 1000)
+        expect(method_class).to receive(:create).with(hash_including(parent_id: hits_id,
+                                                                     attrs: resource_method))
+                                                .and_return(method)
+        expect(method).to receive(:attrs).and_return(resource_method)
         expect { subject.call }.to output(/Created method/).to_stdout
-      end
-
-      context 'and create_method returns error' do
-        it 'then error raised' do
-          expect(service).to receive(:create_method).and_return('errors' => 'some error')
-          expect { subject.call }.to raise_error(ThreeScaleToolbox::Error,
-                                                 /Method has not been created/)
-        end
       end
     end
   end

--- a/spec/unit/commands/plans_command/import/import_plan_pricing_rules_step_spec.rb
+++ b/spec/unit/commands/plans_command/import/import_plan_pricing_rules_step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::ImportPricingRulesStep do
-  let(:threescale_client) { double('threescale_client') }
+  let(:threescale_client) { instance_double('ThreeScale::API::Client', 'threescale_client') }
   let(:service_system_name) { 'myservice' }
   let(:service_class) { class_double('ThreeScaleToolbox::Entities::Service').as_stubbed_const }
   let(:service_info) { { remote: threescale_client, ref: service_system_name } }

--- a/spec/unit/commands/plans_command/list_command_spec.rb
+++ b/spec/unit/commands/plans_command/list_command_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::List::ListSubcommand d
     }
   end
   let(:options) {}
-  let(:remote) { instance_double('ThreeScale::API') }
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
   subject { described_class.new(options, arguments, nil) }

--- a/spec/unit/commands/plans_command/show_command_spec.rb
+++ b/spec/unit/commands/plans_command/show_command_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Show::ShowSubcommand d
     }
   end
   let(:options) {}
-  let(:remote) { instance_double('ThreeScale::API') }
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
   let(:plan_class) { class_double(ThreeScaleToolbox::Entities::ApplicationPlan).as_stubbed_const }
@@ -46,7 +46,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Show::ShowSubcommand d
       end
 
       it 'name is shown' do
-        expect(plan).to receive(:show).and_return(plan_attrs)
+        expect(plan).to receive(:attrs).and_return(plan_attrs)
         expect { subject.run }.to output(/planA/).to_stdout
       end
     end

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Configuration do
   include_context :temp_dir
 

--- a/spec/unit/copy_service_spec.rb
+++ b/spec/unit/copy_service_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Commands::CopyCommand::CopyServiceSubcommand do
   context '#run' do
     let(:source_service_id) { 100 }
@@ -7,8 +5,8 @@ RSpec.describe ThreeScaleToolbox::Commands::CopyCommand::CopyServiceSubcommand d
     let(:source_system_name) { 'source_name' }
     let(:source_service_obj) { { 'id' => source_service_id, 'system_name' => source_system_name } }
     let(:target_service_obj) { { 'id' => target_service_id } }
-    let(:source_remote) { double('source_remote') }
-    let(:target_remote) { double('target_remote') }
+    let(:source_remote) { instance_double('ThreeScale::API::Client', 'source_remote') }
+    let(:target_remote) { instance_double('ThreeScale::API::Client', 'target_remote') }
     let(:arguments) { { 'service_id': source_service_id } }
     let(:options) do
       {

--- a/spec/unit/entities/method_spec.rb
+++ b/spec/unit/entities/method_spec.rb
@@ -1,0 +1,185 @@
+RSpec.describe ThreeScaleToolbox::Entities::Method do
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
+
+  before :example do
+    allow(service).to receive(:remote).and_return(remote)
+  end
+
+  context 'Method.create' do
+    let(:service_id) { 1000 }
+    let(:parent_id) { 1 }
+    let(:method_attrs) { { system_name: 'some name' } }
+
+    before :example do
+      allow(service).to receive(:id).and_return(service_id)
+      expect(remote).to receive(:create_method).with(service_id, parent_id, method_attrs)
+                                              .and_return(remote_response)
+    end
+
+    context 'when remote return error' do
+      let(:remote_response) { { 'errors' => true } }
+
+      it 'throws error on remote error' do
+        expect do
+          described_class.create(service: service, parent_id: parent_id, attrs: method_attrs)
+        end.to raise_error(ThreeScaleToolbox::ThreeScaleApiError, /Method has not been created/)
+      end
+    end
+
+    context 'when remote call succeeds' do
+      let(:remote_response) { { 'id' => 'some_id' } }
+
+      it 'method instance is returned' do
+        method_obj = described_class.create(service: service, parent_id: parent_id,
+                                            attrs: method_attrs)
+        expect(method_obj).not_to be_nil
+        expect(method_obj.id).to eq('some_id')
+      end
+    end
+  end
+
+  context 'Method.find' do
+    let(:service_id) { 1000 }
+    let(:parent_id) { 1 }
+    let(:method_id) { 2000 }
+    let(:method_system_name) { 'some_system_name' }
+    let(:method_attrs) { { 'id' => method_id, 'system_name' => method_system_name } }
+
+    before :example do
+      allow(service).to receive(:id).and_return(service_id)
+    end
+
+    context 'method is found by id' do
+      let(:method_ref) { method_id }
+
+      before :example do
+        expect(remote).to receive(:show_method).with(service_id, parent_id, method_ref)
+                                               .and_return(method_attrs)
+      end
+
+      it 'method instance is returned' do
+        method_obj = described_class.find(service: service, parent_id: parent_id, ref: method_ref)
+        expect(method_obj.id).to eq(method_id)
+      end
+    end
+
+    context 'method is found by system_name' do
+      let(:method_ref) { method_system_name }
+      let(:methods) { [method_attrs] }
+
+      before :example do
+        expect(remote).to receive(:show_method).with(service_id, parent_id, method_ref)
+                                               .and_raise(ThreeScale::API::HttpClient::NotFoundError)
+        expect(service).to receive(:methods).with(parent_id).and_return(methods)
+      end
+
+      it 'method instance is returned' do
+        method_obj = described_class.find(service: service, parent_id: parent_id, ref: method_ref)
+        expect(method_obj).not_to be_nil
+        expect(method_obj.id).to eq(method_id)
+      end
+    end
+
+    context 'method is not found' do
+      let(:method_ref) { method_system_name }
+      let(:methods) { [] }
+
+      before :example do
+        expect(remote).to receive(:show_method).with(service_id, parent_id, method_ref)
+                                               .and_raise(ThreeScale::API::HttpClient::NotFoundError)
+        expect(service).to receive(:methods).with(parent_id).and_return(methods)
+      end
+
+      it 'method instance is not returned' do
+        expect(described_class.find(service: service, parent_id: parent_id, ref: method_ref)).to be_nil
+      end
+    end
+  end
+
+  context 'instance method' do
+    let(:id) { 1774 }
+    let(:service_id) { 4771 }
+    let(:parent_id) { 1 }
+    let(:method_attrs) { nil }
+    subject do
+      described_class.new(id: id, service: service, parent_id: parent_id, attrs: method_attrs)
+    end
+
+    before :example do
+      allow(service).to receive(:id).and_return(service_id)
+    end
+
+    context '#attrs' do
+      context 'when initialized with empty attrs' do
+        let(:remote_attrs) { { 'id' => id, 'system_name' => 'some_system_name' } }
+
+        before :example do
+          expect(remote).to receive(:show_method).with(service_id, parent_id, id).and_return(remote_attrs)
+        end
+
+        it 'calling attrs fetch method attrs' do
+          expect(subject.attrs).to eq(remote_attrs)
+        end
+      end
+
+      context 'when initialized with not empty attrs' do
+        let(:method_attrs) { { 'id' => id } }
+
+        it 'calling attrs does not fetch metric attrs' do
+          expect(subject.attrs).to eq(method_attrs)
+        end
+      end
+    end
+
+    context '#enable' do
+      let(:metric_class) { class_double(ThreeScaleToolbox::Entities::Metric).as_stubbed_const }
+      let(:metric) { instance_double(ThreeScaleToolbox::Entities::Metric) }
+
+      it 'metric instance is used' do
+        expect(metric_class).to receive(:new).with(id: id, service: service).and_return(metric)
+        expect(metric).to receive(:enable)
+        subject.enable
+      end
+    end
+
+    context '#disable' do
+      let(:metric_class) { class_double(ThreeScaleToolbox::Entities::Metric).as_stubbed_const }
+      let(:metric) { instance_double(ThreeScaleToolbox::Entities::Metric) }
+
+      it 'metric instance is used' do
+        expect(metric_class).to receive(:new).with(id: id, service: service).and_return(metric)
+        expect(metric).to receive(:disable)
+        subject.disable
+      end
+    end
+
+    context '#update' do
+      let(:method_attrs) { { 'id' => id, 'system_name' => 'some name' } }
+      let(:new_method_attrs) { { 'id' => id, 'someattr' => 2, 'system_name' => 'some name' } }
+      let(:response_body) {}
+
+      before :example do
+        expect(remote).to receive(:update_method).with(service_id, parent_id, id, method_attrs)
+                                                 .and_return(response_body)
+      end
+
+      context 'when method is updated' do
+        let(:response_body) { new_method_attrs }
+
+        it 'method new attrs are returned' do
+          expect(subject.update(method_attrs)).to eq(new_method_attrs)
+        end
+      end
+
+      context 'operation returns error' do
+        let(:response_body) { { 'errors' => 'some error' } }
+
+        it 'raises error' do
+          expect { subject.update(method_attrs) }.to raise_error(ThreeScaleToolbox::ThreeScaleApiError,
+                                                                 /Method has not been updated/)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/entities/metric_spec.rb
+++ b/spec/unit/entities/metric_spec.rb
@@ -1,0 +1,244 @@
+RSpec.describe ThreeScaleToolbox::Entities::Metric do
+  let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
+  let(:plan_class) { class_double(ThreeScaleToolbox::Entities::ApplicationPlan).as_stubbed_const }
+
+  before :example do
+    allow(service).to receive(:remote).and_return(remote)
+  end
+
+  context 'Metric.create' do
+    let(:service_id) { 1000 }
+    let(:metric_attrs) { { system_name: 'some name' } }
+
+    before :example do
+      allow(service).to receive(:id).and_return(service_id)
+    end
+
+    it 'throws error on remote error' do
+      expect(remote).to receive(:create_metric).with(service_id, metric_attrs)
+                                               .and_return('errors' => true)
+      expect do
+        described_class.create(service: service, attrs: metric_attrs)
+      end.to raise_error(ThreeScaleToolbox::ThreeScaleApiError, /Metric has not been created/)
+    end
+
+    it 'metric instance is returned' do
+      expect(remote).to receive(:create_metric).with(service_id, metric_attrs)
+                                               .and_return('id' => 'some_id')
+      metric_obj = described_class.create(service: service, attrs: metric_attrs)
+      expect(metric_obj.id).to eq('some_id')
+    end
+  end
+
+  context 'Metric.find' do
+    let(:service_id) { 1000 }
+    let(:metric_id) { 2000 }
+    let(:metric_system_name) { 'some_system_name' }
+    let(:metric_attrs) { { 'id' => metric_id, 'system_name' => metric_system_name } }
+
+    before :example do
+      allow(service).to receive(:id).and_return(service_id)
+    end
+
+    context 'metric is found by id' do
+      let(:metric_ref) { metric_id }
+
+      before :example do
+        expect(remote).to receive(:show_metric).with(service_id, metric_ref)
+                                               .and_return(metric_attrs)
+      end
+
+      it 'metric instance is returned' do
+        metric_obj = described_class.find(service: service, ref: metric_ref)
+        expect(metric_obj.id).to eq(metric_id)
+      end
+    end
+
+    context 'metric is found by system_name' do
+      let(:metric_ref) { metric_system_name }
+      let(:metrics) { [metric_attrs] }
+
+      before :example do
+        expect(remote).to receive(:show_metric).with(service_id, metric_ref)
+                                               .and_raise(ThreeScale::API::HttpClient::NotFoundError)
+        expect(service).to receive(:metrics).and_return(metrics)
+      end
+
+      it 'metric instance is returned' do
+        metric_obj = described_class.find(service: service, ref: metric_ref)
+        expect(metric_obj.id).to eq(metric_id)
+      end
+    end
+
+    context 'metric is not found' do
+      let(:metric_ref) { metric_system_name }
+      let(:metrics) { [] }
+
+      before :example do
+        expect(remote).to receive(:show_metric).with(service_id, metric_ref)
+                                               .and_raise(ThreeScale::API::HttpClient::NotFoundError)
+        expect(service).to receive(:metrics).and_return(metrics)
+      end
+
+      it 'metric instance is not returned' do
+        expect(described_class.find(service: service, ref: metric_ref)).to be_nil
+      end
+    end
+  end
+
+  context 'instance method' do
+    let(:id) { 1774 }
+    let(:service_id) { 4771 }
+    let(:metric_attrs) { nil }
+    subject { described_class.new(id: id, service: service, attrs: metric_attrs) }
+
+    before :example do
+      allow(service).to receive(:id).and_return(service_id)
+    end
+
+    context '#attrs' do
+      context 'when initialized with empty attrs' do
+        let(:remote_attrs) { { 'id' => id, 'system_name' => 'some_system_name' } }
+
+        before :example do
+          expect(remote).to receive(:show_metric).with(service_id, id).and_return(remote_attrs)
+        end
+
+        it 'calling attrs fetch metric attrs' do
+          expect(subject.attrs).to eq(remote_attrs)
+        end
+      end
+
+      context 'when initialized with not empty attrs' do
+        let(:metric_attrs) { { 'id' => id } }
+
+        it 'calling attrs does not fetch metric attrs' do
+          expect(subject.attrs).to eq(metric_attrs)
+        end
+      end
+    end
+
+    context '#enable' do
+      let(:plans) do
+        [
+          { 'id' => 1 },
+          { 'id' => 2 },
+          { 'id' => 3 }
+        ]
+      end
+      let(:plan_1) { instance_double('ThreeScaleToolbox::Entities::ApplicationPlan') }
+      let(:plan_2) { instance_double('ThreeScaleToolbox::Entities::ApplicationPlan') }
+      let(:plan_3) { instance_double('ThreeScaleToolbox::Entities::ApplicationPlan') }
+      let(:limit_0_disabled) { { 'id' => 0, 'metric_id' => id, 'period' => 'eternity', 'value' => 0 } }
+      let(:limit_1) { { 'id' => 1, 'metric_id' => id, 'period' => 'eternity', 'value' => 100 } }
+      let(:limit_2_disabled) { { 'id' => 2, 'metric_id' => id, 'period' => 'eternity', 'value' => 0 } }
+      let(:limit_3) { { 'id' => 3, 'metric_id' => id, 'period' => 'year', 'value' => 0 } }
+
+      before :example do
+        expect(service).to receive(:plans).and_return(plans)
+        expect(plan_class).to receive(:new).with(id: 1, service: service).and_return(plan_1)
+        expect(plan_class).to receive(:new).with(id: 2, service: service).and_return(plan_2)
+        expect(plan_class).to receive(:new).with(id: 3, service: service).and_return(plan_3)
+        expect(plan_1).to receive(:metric_limits).with(id).and_return([limit_0_disabled])
+        expect(plan_2).to receive(:metric_limits).with(id).and_return([limit_1])
+        expect(plan_3).to receive(:metric_limits).with(id).and_return([limit_2_disabled, limit_3])
+      end
+
+      it 'eternity zero limits deleted' do
+        expect(plan_1).to receive(:delete_limit).with(id, limit_0_disabled.fetch('id'))
+        expect(plan_3).to receive(:delete_limit).with(id, limit_2_disabled.fetch('id'))
+
+        subject.enable
+      end
+    end
+
+    context '#disable' do
+      let(:zero_eternity_limit_attrs) { { 'period' => 'eternity', 'value' => 0 } }
+      let(:plans) do
+        [
+          { 'id' => 0 },
+          { 'id' => 1 },
+          { 'id' => 2 }
+        ]
+      end
+      let(:plan_0) { instance_double('ThreeScaleToolbox::Entities::ApplicationPlan') }
+      let(:plan_1) { instance_double('ThreeScaleToolbox::Entities::ApplicationPlan') }
+      let(:plan_2) { instance_double('ThreeScaleToolbox::Entities::ApplicationPlan') }
+
+      before :example do
+        expect(service).to receive(:plans).and_return(plans)
+        expect(plan_class).to receive(:new).with(id: 0, service: service).and_return(plan_0)
+        expect(plan_class).to receive(:new).with(id: 1, service: service).and_return(plan_1)
+        expect(plan_class).to receive(:new).with(id: 2, service: service).and_return(plan_2)
+        expect(plan_0).to receive(:metric_limits).with(id).and_return([limit_0])
+        expect(plan_1).to receive(:metric_limits).with(id).and_return([limit_1])
+        expect(plan_2).to receive(:metric_limits).with(id).and_return([limit_2])
+      end
+
+      context 'when eternity non zero limits exist' do
+        let(:limit_0) { { 'id' => 0, 'metric_id' => id, 'period' => 'eternity', 'value' => 1000 } }
+        let(:limit_1) { { 'id' => 1, 'metric_id' => id, 'period' => 'eternity', 'value' => 2000 } }
+        let(:limit_2) { { 'id' => 2, 'metric_id' => id, 'period' => 'eternity', 'value' => 1000 } }
+
+        it 'eternity non zero limits updated' do
+          expect(plan_0).to receive(:update_limit).with(id, limit_0.fetch('id'), zero_eternity_limit_attrs)
+          expect(plan_1).to receive(:update_limit).with(id, limit_1.fetch('id'), zero_eternity_limit_attrs)
+          expect(plan_2).to receive(:update_limit).with(id, limit_2.fetch('id'), zero_eternity_limit_attrs)
+          subject.disable
+        end
+      end
+
+      context 'when no eternity limits exist' do
+        let(:limit_0) { { 'id' => 0, 'metric_id' => id, 'period' => 'year', 'value' => 1000 } }
+        let(:limit_1) { { 'id' => 1, 'metric_id' => id, 'period' => 'month', 'value' => 2000 } }
+        let(:limit_2) { { 'id' => 2, 'metric_id' => id, 'period' => 'day', 'value' => 1000 } }
+
+        it 'eternity zero limits created' do
+          expect(plan_0).to receive(:create_limit).with(id, zero_eternity_limit_attrs)
+          expect(plan_1).to receive(:create_limit).with(id, zero_eternity_limit_attrs)
+          expect(plan_2).to receive(:create_limit).with(id, zero_eternity_limit_attrs)
+          subject.disable
+        end
+      end
+
+      context 'when eternity zero limit exist' do
+        let(:limit_0) { { 'id' => 0, 'metric_id' => id, 'period' => 'eternity', 'value' => 0 } }
+        let(:limit_1) { { 'id' => 1, 'metric_id' => id, 'period' => 'eternity', 'value' => 0 } }
+        let(:limit_2) { { 'id' => 2, 'metric_id' => id, 'period' => 'eternity', 'value' => 0 } }
+
+        it 'noop' do
+          subject.disable
+        end
+      end
+    end
+
+    context '#update' do
+      let(:metric_attrs) { { 'id' => id, 'system_name' => 'some name' } }
+      let(:new_metric_attrs) { { 'id' => id, 'someattr' => 2, 'system_name' => 'some name' } }
+      let(:response_body) {}
+
+      before :example do
+        expect(remote).to receive(:update_metric).with(service_id, id, metric_attrs)
+                                                 .and_return(response_body)
+      end
+
+      context 'when metric is updated' do
+        let(:response_body) { new_metric_attrs }
+
+        it 'metric new attrs are returned' do
+          expect(subject.update(metric_attrs)).to eq(new_metric_attrs)
+        end
+      end
+
+      context 'operation returns error' do
+        let(:response_body) { { 'errors' => 'some error' } }
+
+        it 'raises error' do
+          expect { subject.update(metric_attrs) }.to raise_error(ThreeScaleToolbox::ThreeScaleApiError,
+                                                                 /Metric has not been updated/)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/error_handler_spec.rb
+++ b/spec/unit/error_handler_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::CLI::ErrorHandler do
   include_context :temp_dir
 

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Helper do
   include_context :random_name
 

--- a/spec/unit/plugin_spec.rb
+++ b/spec/unit/plugin_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe 'Plugin command' do
   include_context :temp_dir
   include_context :plugin

--- a/spec/unit/remotes_spec.rb
+++ b/spec/unit/remotes_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Remotes do
   include_context :resources
   include_context :temp_dir

--- a/spec/unit/resource_reader_spec.rb
+++ b/spec/unit/resource_reader_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.shared_examples 'content is read' do
   let(:result) { subject.read_content(resource) }
 

--- a/spec/unit/swagger/swagger_spec.rb
+++ b/spec/unit/swagger/swagger_spec.rb
@@ -1,5 +1,3 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Swagger do
   let(:raw_specification) { YAML.safe_load(content) }
   let(:validate) { true }

--- a/spec/unit/tasks/copy_activedocs_spec.rb
+++ b/spec/unit/tasks/copy_activedocs_spec.rb
@@ -1,12 +1,10 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::CopyActiveDocsTask do
   context '#call' do
     let(:source_service_id) { '10'}
     let(:target_service_id) { '20' }
-    let(:source) { double('source') }
-    let(:target) { double('target') }
-    let(:remote) { double('remote') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
+    let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
     let(:activedocs0) do
       {
         'id' => 0, 'name' => 'ad_0', 'system_name' => 'ad_0', 'service_id' => source_service_id
@@ -22,7 +20,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyActiveDocsTask do
     subject { described_class.new(source: source, target: target) }
 
     before :each do
-      expect(source).to receive(:list_activedocs).and_return(activedocs)
+      expect(source).to receive(:activedocs).and_return(activedocs)
       allow(target).to receive(:id).and_return(target_service_id)
       allow(target).to receive(:remote).and_return(remote)
     end

--- a/spec/unit/tasks/copy_app_plans_task_spec.rb
+++ b/spec/unit/tasks/copy_app_plans_task_spec.rb
@@ -1,9 +1,7 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::CopyApplicationPlansTask do
   context '#call' do
-    let(:source) { double('source') }
-    let(:target) { double('target') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
     2.times do |idx|
       let("plan_#{idx}".to_sym) do
         {

--- a/spec/unit/tasks/copy_limits_task_spec.rb
+++ b/spec/unit/tasks/copy_limits_task_spec.rb
@@ -1,11 +1,9 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::CopyLimitsTask do
   context '#call' do
-    let(:source) { double('source') }
-    let(:source_remote) { double('source_remote') }
-    let(:target) { double('target') }
-    let(:target_remote) { double('target_remote') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
+    let(:source_remote) { instance_double('ThreeScale::API::Client', 'source_remote') }
+    let(:target_remote) { instance_double('ThreeScale::API::Client', 'target_remote') }
     let(:plan_0) do
       {
         'id' => 0,

--- a/spec/unit/tasks/copy_mapping_rules_task_spec.rb
+++ b/spec/unit/tasks/copy_mapping_rules_task_spec.rb
@@ -1,9 +1,7 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::CopyMappingRulesTask do
   context '#call' do
-    let(:source) { double('source') }
-    let(:target) { double('target') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
     let(:metric_0) do
       {
         'id' => 0,

--- a/spec/unit/tasks/copy_methods_task_spec.rb
+++ b/spec/unit/tasks/copy_methods_task_spec.rb
@@ -1,9 +1,8 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::CopyMethodsTask do
   context '#call' do
-    let(:source) { double('source') }
-    let(:target) { double('target') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
+    let(:method_class) { class_double('ThreeScaleToolbox::Entities::Method').as_stubbed_const }
     let(:method_0) do
       {
         'id' => 0,
@@ -54,10 +53,10 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyMethodsTask do
 
       it 'it calls create_method method' do
         # original method has been filtered
-        expect(target).to receive(:create_method).with(
-          target_hits_metric_id,
-          hash_including('system_name' => method_0['system_name'],
-                         'friendly_name' => method_0['friendly_name'])
+        expect(method_class).to receive(:create).with(service: target,
+                                                      parent_id: target_hits_metric_id,
+                                                      attrs: hash_including('system_name' => method_0['system_name'],
+                                                                            'friendly_name' => method_0['friendly_name'])
         )
         expect { subject.call }.to output(/created 1 missing methods/).to_stdout
       end

--- a/spec/unit/tasks/copy_metrics_task_spec.rb
+++ b/spec/unit/tasks/copy_metrics_task_spec.rb
@@ -1,9 +1,8 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::CopyMetricsTask do
   context '#call' do
-    let(:source) { double('source') }
-    let(:target) { double('target') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
+    let(:metric_class) { class_double('ThreeScaleToolbox::Entities::Metric').as_stubbed_const }
     let(:metric_0) do
       {
         'id' => 0,
@@ -48,11 +47,10 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyMetricsTask do
       let(:target_metrics) { [metric_1] }
 
       it 'it calls create_metric method' do
-        expect(target).to receive(:create_metric).with(
-          hash_including('name' => metric_0['name'],
-                         'system_name' => metric_0['system_name'],
-                         'unit' => metric_0['unit'])
-        )
+        expect(metric_class).to receive(:create).with(service: target,
+                                                      attrs: hash_including('name' => metric_0['name'],
+                                                                            'system_name' => metric_0['system_name'],
+                                                                            'unit' => metric_0['unit']))
         expect { subject.call }.to output(/created 1 metrics/).to_stdout
       end
     end

--- a/spec/unit/tasks/copy_policies_task_spec.rb
+++ b/spec/unit/tasks/copy_policies_task_spec.rb
@@ -1,9 +1,7 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::CopyPoliciesTask do
   context '#call' do
-    let(:source) { double('source') }
-    let(:target) { double('target') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
     let(:source_policies) { [] }
 
     subject { described_class.new(source: source, target: target) }

--- a/spec/unit/tasks/copy_pricingrules_task_spec.rb
+++ b/spec/unit/tasks/copy_pricingrules_task_spec.rb
@@ -1,11 +1,9 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::CopyPricingRulesTask do
   context '#call' do
-    let(:source) { double('source') }
-    let(:target) { double('target') }
-    let(:source_remote) { double('source_remote') }
-    let(:target_remote) { double('target_remote') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
+    let(:source_remote) { instance_double('ThreeScale::API::Client', 'source_remote') }
+    let(:target_remote) { instance_double('ThreeScale::API::Client', 'target_remote') }
     let(:plan_0) { { 'id' => 0, 'name' => 'plan_0', 'system_name' => 'plan_0' } }
     let(:plan_1) { { 'id' => 1, 'name' => 'plan_1', 'system_name' => 'plan_1' } }
     let(:metric_0) { { 'id' => 0, 'name' => 'metric_0', 'system_name' => 'metric_0' } }

--- a/spec/unit/tasks/copy_service_proxy_task_spec.rb
+++ b/spec/unit/tasks/copy_service_proxy_task_spec.rb
@@ -1,9 +1,7 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::CopyServiceProxyTask do
   context '#call' do
-    let(:source) { double('source') }
-    let(:target) { double('target') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
     let(:target_id) { 2 }
     let(:source_proxy) do
       {
@@ -19,7 +17,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyServiceProxyTask do
 
     context '1 missing rule' do
       it 'it calls update_proxy method' do
-        expect(source).to receive(:show_proxy).and_return(source_proxy)
+        expect(source).to receive(:proxy).and_return(source_proxy)
         expect(target).to receive(:update_proxy).with(source_proxy)
         expect(target).to receive(:id).and_return(target_id)
         expect { subject.call }.to output(/updated proxy of #{target_id}/).to_stdout

--- a/spec/unit/tasks/delete_activedocs_task_spec.rb
+++ b/spec/unit/tasks/delete_activedocs_task_spec.rb
@@ -1,9 +1,7 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::DeleteActiveDocsTask do
   context '#call' do
-    let(:target) { double('target') }
-    let(:remote) { double('remote') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
+    let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
     subject { described_class.new(target: target) }
 
     before :each do
@@ -17,7 +15,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::DeleteActiveDocsTask do
       end
 
       it 'it calls delete_activedocs method on each activedocs' do
-        expect(target).to receive(:list_activedocs).and_return(target_activedocs)
+        expect(target).to receive(:activedocs).and_return(target_activedocs)
         expect(target_activedocs.size).to be > 0
         target_activedocs.each do |activedocs|
           expect(remote).to receive(:delete_activedocs).with(activedocs['id'])

--- a/spec/unit/tasks/destroy_mapping_rules_task_spec.rb
+++ b/spec/unit/tasks/destroy_mapping_rules_task_spec.rb
@@ -1,8 +1,6 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::DestroyMappingRulesTask do
   context '#call' do
-    let(:target) { double('target') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
     subject { described_class.new(target: target) }
 
     context 'several mapping rules available' do

--- a/spec/unit/tasks/update_service_settings_task_spec.rb
+++ b/spec/unit/tasks/update_service_settings_task_spec.rb
@@ -1,9 +1,7 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Tasks::UpdateServiceSettingsTask do
   context '#call' do
-    let(:source) { double('source') }
-    let(:target) { double('target') }
+    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
+    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
     let(:target_id) { 2 }
     let(:deployment_option) { 'hosted' }
     let(:service_settings) do
@@ -20,12 +18,12 @@ RSpec.describe ThreeScaleToolbox::Tasks::UpdateServiceSettingsTask do
     subject { described_class.new(source: source, target: target, target_name: target_name) }
 
     before :each do
-      expect(source).to receive(:show_service).and_return(service_settings)
+      expect(source).to receive(:attrs).and_return(service_settings)
     end
 
     context 'remote respond with error' do
       it 'error raised' do
-        expect(target).to receive(:update_service).and_return(common_error_response)
+        expect(target).to receive(:update).and_return(common_error_response)
         expect { subject.call }.to raise_error(ThreeScaleToolbox::Error, /not been saved/)
       end
     end
@@ -41,17 +39,17 @@ RSpec.describe ThreeScaleToolbox::Tasks::UpdateServiceSettingsTask do
 
       it 'deployment config is set to hosted' do
         expect(source).to receive(:id).and_return(service_id)
-        expect(target).to receive(:update_service).with(hash_including('deployment_option'))
+        expect(target).to receive(:update).with(hash_including('deployment_option'))
                                                   .and_return(invalid_deployment_error_response)
-        expect(target).to receive(:update_service).with(hash_excluding('deployment_option'))
+        expect(target).to receive(:update).with(hash_excluding('deployment_option'))
                                                   .and_return(positive_response)
         expect { subject.call }.to output(/updated service settings for service id #{service_id}/).to_stdout
       end
 
       it 'throws error when second request returns error' do
-        expect(target).to receive(:update_service).with(hash_including('deployment_option'))
+        expect(target).to receive(:update).with(hash_including('deployment_option'))
                                                   .and_return(invalid_deployment_error_response)
-        expect(target).to receive(:update_service).with(hash_excluding('deployment_option'))
+        expect(target).to receive(:update).with(hash_excluding('deployment_option'))
                                                   .and_return(common_error_response)
         expect { subject.call }.to raise_error(ThreeScaleToolbox::Error, /not been saved/)
       end
@@ -63,7 +61,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::UpdateServiceSettingsTask do
 
       it 'service settings does not contain system_name' do
         expect(source).to receive(:id).and_return(service_id)
-        expect(target).to receive(:update_service).with(expected_svc_settings).and_return('errors' => nil)
+        expect(target).to receive(:update).with(expected_svc_settings).and_return('errors' => nil)
         expect { subject.call }.to output(/updated service settings for service id #{service_id}/).to_stdout
       end
     end
@@ -73,7 +71,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::UpdateServiceSettingsTask do
 
       it 'service settings contains new provided system_name' do
         expect(source).to receive(:id).and_return(service_id)
-        expect(target).to receive(:update_service).with(expected_svc_settings).and_return('errors' => nil)
+        expect(target).to receive(:update).with(expected_svc_settings).and_return('errors' => nil)
         expect { subject.call }.to output(/updated service settings for service id #{service_id}/).to_stdout
       end
     end

--- a/spec/unit/update_service_spec.rb
+++ b/spec/unit/update_service_spec.rb
@@ -1,10 +1,6 @@
-require '3scale_toolbox'
-
 RSpec.describe ThreeScaleToolbox::Commands::UpdateCommand::UpdateServiceSubcommand do
   RSpec.shared_examples 'check tasks' do
     it 'all required tasks are run' do
-      # Remote stub
-      remote = double('remote')
       expect(subject).to receive(:threescale_client).twice.and_return(remote)
 
       # Entities::Service instance stub
@@ -30,6 +26,7 @@ RSpec.describe ThreeScaleToolbox::Commands::UpdateCommand::UpdateServiceSubcomma
   end
 
   context '#run' do
+    let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
     let(:source) { 'https://source_key@source.example.com' }
     let(:destination) { 'https://destination_key@destination.example.com' }
     let(:target_system_name) { 'some_system_name' }


### PR DESCRIPTION
* Create metric
```
NAME
    create - create metric

USAGE
    3scale metrics create [opts] <remote>
    <service> <metric_name>

DESCRIPTION
    Create metric

OPTIONS
       --description=<value>      Metric description
       --disabled                 Disables this metric in all application
                                  plans
    -t --system-name=<value>      Application plan system name
       --unit=<value>             Metric unit. Default hit

OPTIONS FOR METRICS
    -c --config-file=<value>      3scale toolbox configuration file (default:
                                  $HOME/.3scalerc.yaml)
    -h --help                     show help for this command
    -k --insecure                 Proceed and operate even for server
                                  connections otherwise considered insecure
    -v --version                  Prints the version of this command
       --verbose                  Verbose mode
```
* List metrics
```
NAME
    list - list metrics

USAGE
    3scale metrics list [opts] <remote> <service>

DESCRIPTION
    List metrics

OPTIONS FOR METRICS
    -c --config-file=<value>      3scale toolbox configuration file (default:
                                  $HOME/.3scalerc.yaml)
    -h --help                     show help for this command
    -k --insecure                 Proceed and operate even for server
                                  connections otherwise considered insecure
    -v --version                  Prints the version of this command
       --verbose                  Verbose mode
```
* Apply metric
```
NAME
    apply - Update metric

USAGE
    3scale metrics apply [opts] <remote> <service>
    <metric>

DESCRIPTION
    Update (create if it does not exist) metric

OPTIONS
       --description=<value>      Metric description
       --disabled                 Disables this metric in all application
                                  plans
       --enabled                  Enables this metric in all application
                                  plans
    -n --name=<value>             Metric name
       --unit=<value>             Metric unit. Default hit

OPTIONS FOR METRICS
    -c --config-file=<value>      3scale toolbox configuration file (default:
                                  $HOME/.3scalerc.yaml)
    -h --help                     show help for this command
    -k --insecure                 Proceed and operate even for server
                                  connections otherwise considered insecure
    -v --version                  Prints the version of this command
       --verbose                  Verbose mode
```
* Delete metric
```
NAME
    delete - delete metric

USAGE
    3scale metrics delete [opts] <remote>
    <service> <metric>

DESCRIPTION
    Delete metric

OPTIONS FOR METRICS
    -c --config-file=<value>      3scale toolbox configuration file (default:
                                  $HOME/.3scalerc.yaml)
    -h --help                     show help for this command
    -k --insecure                 Proceed and operate even for server
                                  connections otherwise considered insecure
    -v --version                  Prints the version of this command
       --verbose                  Verbose mode
```
* Create method
```
NAME
    create - create method

USAGE
    3scale methods create [opts] <remote>
    <service> <method_name>

DESCRIPTION
    Create method

OPTIONS
       --description=<value>      Metric description
       --disabled                 Disables this method in all application
                                  plans
    -t --system-name=<value>      Method system name

OPTIONS FOR METHODS
    -c --config-file=<value>      3scale toolbox configuration file (default:
                                  $HOME/.3scalerc.yaml)
    -h --help                     show help for this command
    -k --insecure                 Proceed and operate even for server
                                  connections otherwise considered insecure
    -v --version                  Prints the version of this command
       --verbose                  Verbose mode
```
* List methods 
```
NAME
    list - list methods

USAGE
    3scale methods list [opts] <remote> <service>

DESCRIPTION
    List methods

OPTIONS FOR METHODS
    -c --config-file=<value>      3scale toolbox configuration file (default:
                                  $HOME/.3scalerc.yaml)
    -h --help                     show help for this command
    -k --insecure                 Proceed and operate even for server
                                  connections otherwise considered insecure
    -v --version                  Prints the version of this command
       --verbose                  Verbose mode
```
* Apply method 
```
NAME
    apply - Update method

USAGE
    3scale methods apply [opts] <remote> <service>
    <method>

DESCRIPTION
    Update (create if it does not exist) method

OPTIONS
       --description=<value>      Method description
       --disabled                 Disables this method in all application
                                  plans
       --enabled                  Enables this method in all application
                                  plans
    -n --name=<value>             Method name

OPTIONS FOR METHODS
    -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
    -h --help                     show help for this command
    -k --insecure                 Proceed and operate even for server
                                  connections otherwise considered insecure
    -v --version                  Prints the version of this command
       --verbose                  Verbose mode
```
* Delete method
```
NAME
    delete - delete method

USAGE
    3scale methods delete [opts] <remote>
    <service> <method>

DESCRIPTION
    Delete method

OPTIONS FOR METHODS
    -c --config-file=<value>      3scale toolbox configuration file (default:
                                  $HOME/.3scalerc.yaml)
    -h --help                     show help for this command
    -k --insecure                 Proceed and operate even for server
                                  connections otherwise considered insecure
    -v --version                  Prints the version of this command
       --verbose                  Verbose mode
```

Fixes #43 