### PR TITLE
Remote add change validation method

### DIFF
--- a/lib/3scale_toolbox/commands/remote_command/remote_add.rb
+++ b/lib/3scale_toolbox/commands/remote_command/remote_add.rb
@@ -31,7 +31,7 @@ module ThreeScaleToolbox
           # parsing url before trying to create client
           # raises Invalid URL when syntax is incorrect
           ThreeScaleToolbox::Helper.parse_uri(remote_url_str)
-          threescale_client(remote_url_str).list_services
+          threescale_client(remote_url_str).list_accounts
         rescue ThreeScale::API::HttpClient::ForbiddenError
           raise ThreeScaleToolbox::Error, 'remote not valid'
         end

--- a/spec/integration/remote_add_spec.rb
+++ b/spec/integration/remote_add_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ThreeScaleToolbox::Commands::RemoteCommand::RemoteAddSubcommand d
         FileUtils.cp(File.join(resources_path, 'valid_config_file.yaml'),
                      tmp_dir)
         stub_request(:get, /example.com/).to_return(status: 200,
-                                                    body: '{"services": []}')
+                                                    body: '{"accounts": []}')
       end
       let(:configuration) { ThreeScaleToolbox::Configuration.new(config_file) }
 


### PR DESCRIPTION
Changed remote validation from list_services to list_accounts

list_services it returns a 403 when calling it from the master user on a master account. Due to this the remote couldn't be added.