### PR TITLE
fix metric method command name

### DIFF
--- a/docs/method.md
+++ b/docs/method.md
@@ -19,7 +19,7 @@ NAME
     create - create method
 
 USAGE
-    3scale methods create [opts] <remote>
+    3scale method create [opts] <remote>
     <service> <method-name>
 
 DESCRIPTION
@@ -31,7 +31,7 @@ OPTIONS
                                   plans
     -t --system-name=<value>      Method system name
 
-OPTIONS FOR METHODS
+OPTIONS FOR METHOD
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
     -h --help                     show help for this command
@@ -56,7 +56,7 @@ NAME
     apply - Update method
 
 USAGE
-    3scale methods apply [opts] <remote> <service>
+    3scale method apply [opts] <remote> <service>
     <method>
 
 DESCRIPTION
@@ -70,7 +70,7 @@ OPTIONS
                                   plans
     -n --name=<value>             Method name
 
-OPTIONS FOR METHODS
+OPTIONS FOR METHOD
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                    $HOME/.3scalerc.yaml)
     -h --help                     show help for this command
@@ -87,12 +87,12 @@ NAME
     list - list methods
 
 USAGE
-    3scale methods list [opts] <remote> <service>
+    3scale method list [opts] <remote> <service>
 
 DESCRIPTION
     List methods
 
-OPTIONS FOR METHODS
+OPTIONS FOR METHOD
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
     -h --help                     show help for this command
@@ -109,13 +109,13 @@ NAME
     delete - delete method
 
 USAGE
-    3scale methods delete [opts] <remote>
+    3scale method delete [opts] <remote>
     <service> <method>
 
 DESCRIPTION
     Delete method
 
-OPTIONS FOR METHODS
+OPTIONS FOR METHOD
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
     -h --help                     show help for this command

--- a/docs/metric.md
+++ b/docs/metric.md
@@ -19,7 +19,7 @@ NAME
     create - create metric
 
 USAGE
-    3scale metrics create [opts] <remote>
+    3scale metric create [opts] <remote>
     <service> <metric-name>
 
 DESCRIPTION
@@ -32,7 +32,7 @@ OPTIONS
     -t --system-name=<value>      Application plan system name
        --unit=<value>             Metric unit. Default hit
 
-OPTIONS FOR METRICS
+OPTIONS FOR METRIC
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
     -h --help                     show help for this command
@@ -57,7 +57,7 @@ NAME
     apply - Update metric
 
 USAGE
-    3scale metrics apply [opts] <remote> <service>
+    3scale metric apply [opts] <remote> <service>
     <metric>
 
 DESCRIPTION
@@ -72,7 +72,7 @@ OPTIONS
     -n --name=<value>             Metric name
        --unit=<value>             Metric unit. Default hit
 
-OPTIONS FOR METRICS
+OPTIONS FOR METRIC
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
     -h --help                     show help for this command
@@ -89,12 +89,12 @@ NAME
     list - list metrics
 
 USAGE
-    3scale metrics list [opts] <remote> <service>
+    3scale metric list [opts] <remote> <service>
 
 DESCRIPTION
     List metrics
 
-OPTIONS FOR METRICS
+OPTIONS FOR METRIC
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
     -h --help                     show help for this command
@@ -111,13 +111,13 @@ NAME
     delete - delete metric
 
 USAGE
-    3scale metrics delete [opts] <remote>
+    3scale metric delete [opts] <remote>
     <service> <metric>
 
 DESCRIPTION
     Delete metric
 
-OPTIONS FOR METRICS
+OPTIONS FOR METRIC
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
     -h --help                     show help for this command

--- a/lib/3scale_toolbox/commands/methods_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command.rb
@@ -9,10 +9,10 @@ module ThreeScaleToolbox
       include ThreeScaleToolbox::Command
       def self.command
         Cri::Command.define do
-          name        'methods'
-          usage       'methods <sub-command> [options]'
-          summary     'methods super command'
-          description 'Methods commands'
+          name        'method'
+          usage       'method <sub-command> [options]'
+          summary     'method super command'
+          description 'Method commands'
 
           run do |_opts, _args, cmd|
             puts cmd.help

--- a/lib/3scale_toolbox/commands/metrics_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command.rb
@@ -9,10 +9,10 @@ module ThreeScaleToolbox
       include ThreeScaleToolbox::Command
       def self.command
         Cri::Command.define do
-          name        'metrics'
-          usage       'metrics <sub-command> [options]'
-          summary     'metrics super command'
-          description 'Metrics commands'
+          name        'metric'
+          usage       'metric <sub-command> [options]'
+          summary     'metric super command'
+          description 'Metric commands'
 
           run do |_opts, _args, cmd|
             puts cmd.help


### PR DESCRIPTION
* Fix `metrics` to `metric`
* Fix `methods` to `method`

When command name is `methods`, `3scale method` is also valid. CRI library allows it. 