### PR TITLE
Fix licenseFinder check

### DIFF
--- a/.dependency_decisions.yml
+++ b/.dependency_decisions.yml
@@ -66,3 +66,9 @@
     :why: MIT License https://github.com/defunkt/colored/blob/master/LICENSE
     :versions: []
     :when: 2018-12-06 16:05:25.674247558 Z
+- - :approve
+  - bundler
+  - :who: 
+    :why: MIT License https://github.com/bundler/bundler/blob/master/LICENSE.md 
+    :versions: []
+    :when: 2019-05-28 09:24:54.882581954 Z

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
+cache: bundler
 before_install:
 - openssl aes-256-cbc -K $encrypted_3d22a8bf1dac_key -iv $encrypted_3d22a8bf1dac_iv
   -in .env.enc -out .env -d
+install: bundle install --jobs=3 --retry=3 --path vendor/bundle
 rvm:
 - 2.6.2
 - 2.5.5


### PR DESCRIPTION
- [x] Install dependencies in local file. Mixing them with system wide installed gems lead to weird errors.
- [x] cache bundle gems in CI builds