### PR TITLE
3scale import openapi set the public staging prod URLs

### DIFF
--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -10,6 +10,7 @@ require '3scale_toolbox/commands/import_command/openapi/create_activedocs_step'
 require '3scale_toolbox/commands/import_command/openapi/update_service_proxy_step'
 require '3scale_toolbox/commands/import_command/openapi/update_service_oidc_conf_step'
 require '3scale_toolbox/commands/import_command/openapi/update_policies_step'
+require '3scale_toolbox/commands/import_command/openapi/bump_proxy_version_step'
 
 module ThreeScaleToolbox
   module Commands
@@ -34,6 +35,8 @@ module ThreeScaleToolbox
               option  nil, 'default-credentials-userkey', 'Default credentials policy userkey', argument: :required
               option  nil, 'override-private-basepath', 'Override the basepath for the public URLs', argument: :required
               option  nil, 'override-public-basepath', 'Override the basepath for the private URLs', argument: :required
+              option  nil, 'staging-public-base-url', 'Custom public staging URL', argument: :required
+              option  nil, 'production-public-base-url', 'Custom public production URL', argument: :required
               param   :openapi_resource
 
               runner OpenAPISubcommand
@@ -43,17 +46,17 @@ module ThreeScaleToolbox
           def run
             tasks = []
             tasks << CreateServiceStep.new(context)
+            # other tasks might read proxy settings (CreateActiveDocsStep does)
+            tasks << UpdateServiceProxyStep.new(context)
             tasks << CreateMethodsStep.new(context)
             tasks << ThreeScaleToolbox::Tasks::DestroyMappingRulesTask.new(context)
             tasks << CreateMappingRulesStep.new(context)
             tasks << CreateActiveDocsStep.new(context)
             tasks << UpdateServiceOidcConfStep.new(context)
             tasks << UpdatePoliciesStep.new(context)
-            # Update proxy must be the last step
-            # Proxy update is the mechanism to increase version of the proxy,
-            # Hence propagating (mapping rules, poicies, oidc, auth) update to
-            # latest proxy config, making available to gateway.
-            tasks << UpdateServiceProxyStep.new(context)
+
+            # This should be the last step
+            tasks << BumpProxyVersionStep.new(context)
 
             # run tasks
             tasks.each(&:call)
@@ -76,7 +79,9 @@ module ThreeScaleToolbox
               oidc_issuer_endpoint: options[:'oidc-issuer-endpoint'],
               default_credentials_userkey: options[:'default-credentials-userkey'],
               skip_openapi_validation: options[:'skip-openapi-validation'],
-              override_private_basepath: options[:'override-private-basepath']
+              override_private_basepath: options[:'override-private-basepath'],
+              production_public_base_url: options[:'production-public-base-url'],
+              staging_public_base_url: options[:'staging-public-base-url']
             }
           end
 

--- a/lib/3scale_toolbox/commands/import_command/openapi/bump_proxy_version_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/bump_proxy_version_step.rb
@@ -1,0 +1,32 @@
+module ThreeScaleToolbox
+  module Commands
+    module ImportCommand
+      module OpenAPI
+        class BumpProxyVersionStep
+          include Step
+
+          ##
+          # bumps proxy config version to propagate proxy settings updates
+          def call
+            # Proxy update is the mechanism to increase version of the proxy,
+            # Hence propagating (mapping rules, poicies, oidc, auth) update to
+            # latest proxy config, making available to gateway.
+
+            # Currently it is done always because mapping rules, at least, are always created
+            # So they need to be propagated
+            proxy_settings = {
+              # Adding harmless attribute to avoid empty body
+              # update_proxy cannot be done with empty body
+              # and must be done to increase proxy version
+              # If proxy settings have not been changed since last update,
+              # this request will not have effect and proxy config version will not be bumped.
+              service_id: service.id
+            }
+
+            service.update_proxy proxy_settings
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/import_command/openapi/create_service_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_service_step.rb
@@ -35,6 +35,7 @@ module ThreeScaleToolbox
               svc['description'] = service_description
               svc['backend_version'] = backend_version
               svc['system_name'] = service_system_name
+              svc['deployment_option'] = 'self_managed' if !production_public_base_url.nil? || !staging_public_base_url.nil?
             end
           end
 

--- a/lib/3scale_toolbox/commands/import_command/openapi/step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/step.rb
@@ -59,6 +59,14 @@ module ThreeScaleToolbox
           def override_private_basepath
             context[:override_private_basepath]
           end
+
+          def production_public_base_url
+            context[:production_public_base_url]
+          end
+
+          def staging_public_base_url
+            context[:staging_public_base_url]
+          end
         end
       end
     end

--- a/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
@@ -8,16 +8,14 @@ module ThreeScaleToolbox
           ##
           # Updates Proxy config
           def call
-            # setting required attrs, operation is idempotent
-            proxy_settings = {
-              # Adding harmless attribute to avoid empty body
-              # update_proxy cannot be done with empty body
-              # and must be done to increase proxy version
-              service_id: service.id
-            }
+            proxy_settings = {}
 
+            add_endpoint_settings(proxy_settings)
+            add_sandbox_endpoint_settings(proxy_settings)
             add_api_backend_settings(proxy_settings)
             add_security_proxy_settings(proxy_settings)
+
+            return unless proxy_settings.size.positive?
 
             res = service.update_proxy proxy_settings
             if (errors = res['errors'])
@@ -28,6 +26,18 @@ module ThreeScaleToolbox
           end
 
           private
+
+          def add_endpoint_settings(settings)
+            return if production_public_base_url.nil?
+
+            settings[:endpoint] = production_public_base_url
+          end
+
+          def add_sandbox_endpoint_settings(settings)
+            return if staging_public_base_url.nil?
+
+            settings[:sandbox_endpoint] = staging_public_base_url
+          end
 
           def add_api_backend_settings(settings)
             return if api_spec.host.nil?

--- a/lib/3scale_toolbox/entities/service.rb
+++ b/lib/3scale_toolbox/entities/service.rb
@@ -143,7 +143,7 @@ module ThreeScaleToolbox
       end
 
       def update(svc_attrs)
-        new_attrs = remote.update_service id, svc_attrs
+        new_attrs = safe_update(svc_attrs)
         if (errors = new_attrs['errors'])
           raise ThreeScaleToolbox::ThreeScaleApiError.new('Service not updated', errors)
         end
@@ -232,6 +232,21 @@ module ThreeScaleToolbox
         end
 
         svc
+      end
+
+      def safe_update(svc_attrs)
+        new_attrs = remote.update_service id, svc_attrs
+
+        # Source and target remotes might not allow same set of deployment options
+        # Invalid deployment option check
+        # use default deployment_option
+        if (errors = new_attrs['errors']) &&
+           ThreeScaleToolbox::Helper.service_invalid_deployment_option?(errors)
+          svc_attrs.delete('deployment_option')
+          new_attrs = remote.update_service id, svc_attrs
+        end
+
+        new_attrs
       end
     end
   end

--- a/spec/unit/commands/import_command/openapi/bump_proxy_version_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/bump_proxy_version_step_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::BumpProxyVersionStep do
+  let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
+  let(:openapi_context) { { target: service } }
+
+  context '#call' do
+    subject { described_class.new(openapi_context).call }
+
+    before :each do
+      allow(service).to receive(:id).and_return(1000)
+    end
+
+    it 'service update proxy method called' do
+      expect(service).to receive(:update_proxy).with(hash_including(service_id: 1000))
+                                               .and_return({})
+      subject
+    end
+  end
+end

--- a/spec/unit/commands/import_command/openapi/create_service_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_service_step_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateServic
     end
 
     context 'when service exists' do
-
       before :example do
         expect(service_class).to receive(:find_by_system_name)
           .with(remote: threescale_client, system_name: openapi_context[:target_system_name])
@@ -45,6 +44,40 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateServic
       it 'service is updated' do
         expect(service).to receive(:update).with(expected_settings)
         expect { subject }.to output(/Updated service id: #{service_id}/).to_stdout
+      end
+
+      context 'and production_public_base_url is in context' do
+        let(:openapi_context) do
+          {
+            target: service,
+            api_spec: api_spec,
+            threescale_client: threescale_client,
+            target_system_name: system_name,
+            production_public_base_url: 'http://api.example.com',
+          }
+        end
+
+        it 'service settings include deployment option' do
+          expect(service).to receive(:update).with(hash_including('deployment_option' => 'self_managed'))
+          expect { subject }.to output.to_stdout
+        end
+      end
+
+      context 'and staging_public_base_url is in context' do
+        let(:openapi_context) do
+          {
+            target: service,
+            api_spec: api_spec,
+            threescale_client: threescale_client,
+            target_system_name: system_name,
+            staging_public_base_url: 'http://api.example.com',
+          }
+        end
+
+        it 'service settings include deployment option' do
+          expect(service).to receive(:update).with(hash_including('deployment_option' => 'self_managed'))
+          expect { subject }.to output.to_stdout
+        end
       end
     end
 

--- a/spec/unit/commands/import_command/openapi_spec.rb
+++ b/spec/unit/commands/import_command/openapi_spec.rb
@@ -22,13 +22,14 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::OpenAPISubco
         # Task stubs
         [
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateServiceStep,
+          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServiceProxyStep,
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMethodsStep,
           ThreeScaleToolbox::Tasks::DestroyMappingRulesTask,
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMappingRulesStep,
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateActiveDocsStep,
-          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServiceProxyStep,
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServiceOidcConfStep,
           ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdatePoliciesStep,
+          ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::BumpProxyVersionStep,
         ].each do |task_class|
           task = instance_double(task_class.to_s)
           task_class_obj = class_double(task_class).as_stubbed_const


### PR DESCRIPTION
the "3scale import openapi" command has to set the public staging/prod URLs
==================================================================

When importing an OpenAPI, the service is created using the SaaS APIcast but there is no mean to specify a custom public staging/prod URL so that I could use my own APIcast instances.

The "3scale import openapi" command has two more optional parameters :
```
--staging-public-base-url=http://my-apicast-instance.mydomain.com:8080
--production-public-base-url=https://api.example.com
```
