### PR TITLE
Copy policy registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See the LICENSE and NOTICE files that should have been provided along with this 
    * Create, Apply, List, Show, Delete [Service](docs/service.md)
    * Create, Apply, List, Delete [ActiveDocs](docs/activedocs.md)
    * List, Show, Promote [Proxy Configuration](docs/proxy-config.md)
+   * [Copy Policy Registry](docs/copy-policy-registry.md)
    * [Remotes](docs/remotes.md)
 * [Development](#development)
    * [Testing](#testing)
@@ -49,11 +50,18 @@ DESCRIPTION
     3scale toolbox to manage your API from the terminal.
 
 COMMANDS
-    copy       copy super command
-    help       show help
-    import     import super command
-    remote     remotes super command
-    update     update super command
+    account              account super command
+    activedocs           activedocs super command
+    application-plan     application-plan super command
+    copy                 copy super command
+    help                 show help
+    import               import super command
+    method               method super command
+    metric               metric super command
+    policy-registry      policy-registry super command
+    remote               remotes super command
+    service              services super command
+    update               update super command
 
 OPTIONS
     -c --config-file=<value>      3scale toolbox configuration file (default:

--- a/docs/copy-policy-registry.md
+++ b/docs/copy-policy-registry.md
@@ -1,0 +1,31 @@
+## Copy Policy Registry
+
+Toolbox command to copy policy registry (a.k.a. `custom policies`) from a source account to a target account.
+* Missing custom policies are being created in target account.
+* Matching custom policies are being updated in target account.
+* This copy command is idempotent.
+
+Missing custom policies are defined as custom policies that exist in source account and do not exist in account tenant.
+
+Matching custom policies are defined as custom policies that exists in both source and target account.
+
+```shell
+NAME
+    copy - Copy policy registry
+
+USAGE
+    3scale policy-registry copy [opts]
+    <source_remote> <target_remote>
+
+DESCRIPTION
+    Copy policy registry
+
+OPTIONS FOR POLICY-REGISTRY
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
+```

--- a/lib/3scale_toolbox/commands.rb
+++ b/lib/3scale_toolbox/commands.rb
@@ -11,6 +11,7 @@ require '3scale_toolbox/commands/service_command'
 require '3scale_toolbox/commands/activedocs_command'
 require '3scale_toolbox/commands/account_command'
 require '3scale_toolbox/commands/proxy_config_command'
+require '3scale_toolbox/commands/policy_registry_command'
 
 module ThreeScaleToolbox
   module Commands
@@ -27,6 +28,7 @@ module ThreeScaleToolbox
       ThreeScaleToolbox::Commands::ActiveDocsCommand,
       ThreeScaleToolbox::Commands::AccountCommand,
       ThreeScaleToolbox::Commands::ProxyConfigCommand,
+      ThreeScaleToolbox::Commands::PolicyRegistryCommand,
     ].freeze
   end
 end

--- a/lib/3scale_toolbox/commands/policy_registry_command.rb
+++ b/lib/3scale_toolbox/commands/policy_registry_command.rb
@@ -1,0 +1,22 @@
+require '3scale_toolbox/commands/policy_registry_command/copy_command'
+
+module ThreeScaleToolbox
+  module Commands
+    module PolicyRegistryCommand
+      include ThreeScaleToolbox::Command
+      def self.command
+        Cri::Command.define do
+          name        'policy-registry'
+          usage       'policy-registry <sub-command> [options]'
+          summary     'policy-registry super command'
+          description 'Pôlicy Registry commands'
+
+          run do |_opts, _args, cmd|
+            puts cmd.help
+          end
+        end
+      end
+      add_subcommand(Copy::CopySubcommand)
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/policy_registry_command/copy_command.rb
+++ b/lib/3scale_toolbox/commands/policy_registry_command/copy_command.rb
@@ -1,0 +1,85 @@
+module ThreeScaleToolbox
+  module Commands
+    module PolicyRegistryCommand
+      module Copy
+        class CopySubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          def self.command
+            Cri::Command.define do
+              name        'copy'
+              usage       'copy [opts] <source_remote> <target_remote>'
+              summary     'Copy policy registry'
+              description 'Copy policy registry'
+
+              param       :source_remote
+              param       :target_remote
+
+              runner CopySubcommand
+            end
+          end
+
+          def run
+            source_policies = source_remote.list_policy_registry
+            if source_policies.respond_to?(:has_key?) && (errors = source_policies['errors'])
+              raise ThreeScaleToolbox::ThreeScaleApiError.new('Could not list source policy registry', errors)
+            end
+
+            target_policies = target_remote.list_policy_registry
+            if target_policies.respond_to?(:has_key?) && (errors = target_policies['errors'])
+              raise ThreeScaleToolbox::ThreeScaleApiError.new('Could not list target policy registry', errors)
+            end
+
+            # Create missing
+            missing = missing_policies(source_policies, target_policies)
+            missing.each do |policy|
+              new_policy_registry = target_remote.create_policy_registry(policy)
+              if (errors = new_policy_registry['errors'])
+                raise ThreeScaleToolbox::ThreeScaleApiError.new('Could not create target policy registry', errors)
+              end
+            end
+
+            # Update those matching
+            matching = matching_policies(source_policies, target_policies)
+            matching.each do |policy|
+              updated_policy = target_remote.update_policy_registry(
+                "#{policy['name']}-#{policy['version']}", policy
+              )
+              if (errors = updated_policy['errors'])
+                raise ThreeScaleToolbox::ThreeScaleApiError.new('Could not update target policy registry', errors)
+              end
+            end
+
+            puts "Created #{missing.size} missing policies on target tenant"
+            puts "Updated #{matching.size} matching policies on target tenant"
+          end
+
+          private
+
+          def missing_policies(source_policies, target_policies)
+            ThreeScaleToolbox::Helper.array_difference(source_policies,
+                                                       target_policies) do |source, target|
+              ThreeScaleToolbox::Helper.compare_hashes(source, target, %w[name version])
+            end
+          end
+
+          def matching_policies(source_policies, target_policies)
+            source_policies.select do |source|
+              target_policies.find do |target|
+                ThreeScaleToolbox::Helper.compare_hashes(source, target, %w[name version])
+              end
+            end
+          end
+
+          def source_remote
+            @source_remote ||= threescale_client(arguments[:source_remote])
+          end
+
+          def target_remote
+            @target_remote ||= threescale_client(arguments[:target_remote])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands/policy_registry_command/copy_command_spec.rb
+++ b/spec/unit/commands/policy_registry_command/copy_command_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe ThreeScaleToolbox::Commands::PolicyRegistryCommand::Copy::CopySubcommand do
+  let(:arguments) { { source_remote: 'source_remote', target_remote: 'target_remote' } }
+  let(:options) { {} }
+  let(:source_remote) { instance_double('ThreeScale::API::Client', 'source_remote') }
+  let(:target_remote) { instance_double('ThreeScale::API::Client', 'target_remote') }
+  subject { described_class.new(options, arguments, nil) }
+
+  context '#run' do
+    context 'source policy registry list returns error' do
+      let(:list_error) { { 'errors' => 'some error happened' } }
+
+      before :example do
+        expect(subject).to receive(:threescale_client).with('source_remote').and_return(source_remote)
+        expect(source_remote).to receive(:list_policy_registry).and_return(list_error)
+      end
+
+      it 'then error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::ThreeScaleApiError, /source/)
+      end
+    end
+
+    context 'target policy registry list returns error' do
+      let(:list_error) { { 'errors' => 'some error happened' } }
+
+      before :example do
+        expect(subject).to receive(:threescale_client).with('source_remote').and_return(source_remote)
+        expect(subject).to receive(:threescale_client).with('target_remote').and_return(target_remote)
+        expect(source_remote).to receive(:list_policy_registry).and_return([])
+        expect(target_remote).to receive(:list_policy_registry).and_return(list_error)
+      end
+
+      it 'then error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::ThreeScaleApiError, /target/)
+      end
+    end
+
+    context 'some missing policies' do
+      let(:source_policies) do
+        [
+          { 'name' => 'p1', 'version' => '0.0.1' },
+          { 'name' => 'p2', 'version' => '0.0.1' },
+          { 'name' => 'p3', 'version' => '0.0.1' }
+        ]
+      end
+      before :example do
+        expect(subject).to receive(:threescale_client).with('source_remote').and_return(source_remote)
+        expect(subject).to receive(:threescale_client).with('target_remote').and_return(target_remote)
+        expect(source_remote).to receive(:list_policy_registry).and_return(source_policies)
+        expect(target_remote).to receive(:list_policy_registry).and_return([])
+      end
+
+      it 'are created in target account' do
+        source_policies.each do |policy|
+          expect(target_remote).to receive(:create_policy_registry).with(policy).and_return({})
+        end
+        expect { subject.run }.to output(/Created #{source_policies.size} missing policies/).to_stdout
+      end
+    end
+
+    context 'some matching policies' do
+      let(:source_policies) do
+        [
+          { 'name' => 'p1', 'version' => '0.0.1', 'newparam' => 'new_value' }
+        ]
+      end
+      let(:target_policies) do
+        [
+          { 'name' => 'p1', 'version' => '0.0.1' },
+          { 'name' => 'p98', 'version' => '0.0.1' },
+          { 'name' => 'p99', 'version' => '0.0.1' }
+        ]
+      end
+      before :example do
+        expect(subject).to receive(:threescale_client).with('source_remote').and_return(source_remote)
+        expect(subject).to receive(:threescale_client).with('target_remote').and_return(target_remote)
+        expect(source_remote).to receive(:list_policy_registry).and_return(source_policies)
+        expect(target_remote).to receive(:list_policy_registry).and_return(target_policies)
+      end
+
+      it 'are updated in target account' do
+        expect(target_remote).to receive(:update_policy_registry).with('p1-0.0.1', source_policies[0]).and_return({})
+        expect { subject.run }.to output(/Updated #{source_policies.size} matching policies/).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
Toolbox command to `copy` policy registry (a.k.a. custom policies) from source tenant to target tenant.
Policy registry identificator is `#{name}-#{version}`. Having this identifying function, we can define
* Missing policies: policies that exist in source tenant and do not exist in target tenant. 
* Matching policies: policies from source tenant that exist in target tenant.

Then:
- [x] Missing policies are being created in target tenant
- [x] Matching policies are being updated in target tenant

This behavior makes the command idempotent.

Integration tests not implemented as they require two different provider accounts.