### PR TITLE
openapi: override private base url THREESCALE-2734

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -26,10 +26,13 @@ NAME
     openapi - Import API defintion in OpenAPI specification from a local file or URL
 
 USAGE
-    3scale import openapi [opts] -d <destination> <spec> (/path/to/your/spec/file.[json|yaml|yml] OR http[s]://domain/resource/path.[json|yaml|yml])
+    3scale import openapi [opts] -d <destination>
+    <spec> (/path/to/your/spec/file.[json|yaml|yml] OR
+    http[s]://domain/resource/path.[json|yaml|yml])
 
 DESCRIPTION
-    Using an API definition format like OpenAPI, import to your 3scale API directly from a local OpenAPI spec compliant file or a remote URL
+    Using an API definition format like OpenAPI, import to your 3scale API
+    directly from a local OpenAPI spec compliant file or a remote URL
 
 OPTIONS
        --activedocs-hidden                        Create ActiveDocs in hidden
@@ -40,22 +43,17 @@ OPTIONS
        --default-credentials-userkey=<value>      Default credentials policy
                                                   userkey
        --oidc-issuer-endpoint=<value>             OIDC Issuer Endpoint
-       --skip-openapi-validation                  Skip OpenAPI schema validation
+       --override-private-base-url=<value>        Custom private base URL
+       --override-private-basepath=<value>        Override the basepath for
+                                                  the private URLs
+       --override-public-basepath=<value>         Override the basepath for
+                                                  the public URLs
+       --production-public-base-url=<value>       Custom public production
+                                                  URL
+       --skip-openapi-validation                  Skip OpenAPI schema
+                                                  validation
+       --staging-public-base-url=<value>          Custom public staging URL
     -t --target_system_name=<value>               Target system name
-
-OPTIONS FOR IMPORT
-    -c --config-file=<value>                      3scale toolbox
-                                                  configuration file
-                                                  (default:
-                                                  $HOME/.3scalerc.yaml)
-    -h --help                                     show help for this command
-    -k --insecure                                 Proceed and operate even
-                                                  for server connections
-                                                  otherwise considered
-                                                  insecure
-    -v --version                                  Prints the version of this
-                                                  command
-       --verbose                                  Verbose mode
 ```
 
 ### OpenAPI definition from filename in path

--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -32,10 +32,11 @@ module ThreeScaleToolbox
               flag    nil, 'skip-openapi-validation', 'Skip OpenAPI schema validation'
               option  nil, 'oidc-issuer-endpoint', 'OIDC Issuer Endpoint', argument: :required
               option  nil, 'default-credentials-userkey', 'Default credentials policy userkey', argument: :required
-              option  nil, 'override-private-basepath', 'Override the basepath for the public URLs', argument: :required
-              option  nil, 'override-public-basepath', 'Override the basepath for the private URLs', argument: :required
+              option  nil, 'override-private-basepath', 'Override the basepath for the private URLs', argument: :required
+              option  nil, 'override-public-basepath', 'Override the basepath for the public URLs', argument: :required
               option  nil, 'staging-public-base-url', 'Custom public staging URL', argument: :required
               option  nil, 'production-public-base-url', 'Custom public production URL', argument: :required
+              option  nil, 'override-private-base-url', 'Custom private base URL', argument: :required
               param   :openapi_resource
 
               runner OpenAPISubcommand
@@ -80,7 +81,8 @@ module ThreeScaleToolbox
               skip_openapi_validation: options[:'skip-openapi-validation'],
               override_private_basepath: options[:'override-private-basepath'],
               production_public_base_url: options[:'production-public-base-url'],
-              staging_public_base_url: options[:'staging-public-base-url']
+              staging_public_base_url: options[:'staging-public-base-url'],
+              override_private_base_url: options[:'override-private-base-url'],
             }
           end
 

--- a/lib/3scale_toolbox/commands/import_command/openapi/step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/step.rb
@@ -66,6 +66,10 @@ module ThreeScaleToolbox
           def staging_public_base_url
             context[:staging_public_base_url]
           end
+
+          def override_private_base_url
+            context[:override_private_base_url]
+          end
         end
       end
     end

--- a/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
@@ -40,12 +40,9 @@ module ThreeScaleToolbox
           end
 
           def add_api_backend_settings(settings)
-            return if api_spec.host.nil?
+            return if private_base_url.nil?
 
-            scheme = api_spec.schemes.first || 'https'
-            host = api_spec.host
-
-            settings[:api_backend] = "#{scheme}://#{host}"
+            settings[:api_backend] = private_base_url
           end
 
           def add_security_proxy_settings(settings)
@@ -73,6 +70,16 @@ module ThreeScaleToolbox
             else
               raise ThreeScaleToolbox::Error, "Unexpected security in_f field #{in_f}"
             end
+          end
+
+          def private_base_url
+              override_private_base_url || private_base_url_from_openapi
+          end
+
+          def private_base_url_from_openapi
+            return if api_spec.host.nil?
+
+            "#{api_spec.schemes.first || 'https'}://#{api_spec.host}"
           end
         end
       end

--- a/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
   let(:security) { nil }
   let(:production_public_base_url) { nil }
   let(:staging_public_base_url) { nil }
+  let(:override_private_base_url) { nil }
   let(:oidc_issuer_endpoint) { 'https://sso.example.com' }
   let(:openapi_context) do
     {
@@ -14,6 +15,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
       oidc_issuer_endpoint: oidc_issuer_endpoint,
       production_public_base_url: production_public_base_url,
       staging_public_base_url: staging_public_base_url,
+      override_private_base_url: override_private_base_url,
     }
   end
 
@@ -59,6 +61,16 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
       it 'api_backend updated' do
         expect(service).to receive(:update_proxy)
           .with(hash_including(api_backend: 'https://example.com')).and_return({})
+        expect { subject }.to output.to_stdout
+      end
+    end
+
+    context 'private base url set' do
+      let(:override_private_base_url) { 'http://echo-api.example.com' }
+
+      it 'api_backend updated' do
+        expect(service).to receive(:update_proxy)
+          .with(hash_including(api_backend: override_private_base_url)).and_return({})
         expect { subject }.to output.to_stdout
       end
     end


### PR DESCRIPTION
Ability to override the private base URL when importing an OpenAPI.

New option parameter for `3scale import openapi` command.

`--override-private-base-url=<value>        Custom private base URL`

By default:  "host" and "schemes" field of the OpenAPI Specification file. 



Signed-off-by: Eguzki Astiz Lezaun <eastizle@redhat.com>