### PR TITLE
copy service: fix copy metric task THREESCALE-2613

### DIFF
--- a/lib/3scale_toolbox/commands/metrics_command/list_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command/list_command.rb
@@ -33,15 +33,8 @@ module ThreeScaleToolbox
           end
 
           def print_data
-            metrics.each do |metric|
+            service.metrics.each do |metric|
               puts FIELDS_TO_SHOW.map { |field| metric.fetch(field, '(empty)') }.join("\t")
-            end
-          end
-
-          def metrics
-            hits_id = service.hits['id']
-            ThreeScaleToolbox::Helper.array_difference(service.metrics, service.methods(hits_id)) do |metric, method|
-              ThreeScaleToolbox::Helper.compare_hashes(metric, method, %w[id])
             end
           end
 

--- a/lib/3scale_toolbox/commands/plans_command/export/read_plan_methods_step.rb
+++ b/lib/3scale_toolbox/commands/plans_command/export/read_plan_methods_step.rb
@@ -26,8 +26,6 @@ module ThreeScaleToolbox
           end
 
           def filtered_limit_methods
-            # has to be filtered this way
-            # looking up in metrics list does not work. Metric list includes methods and metrics
             result[:limits].select { |limit| limit.dig('metric', 'type') == 'method' }
           end
 
@@ -40,7 +38,6 @@ module ThreeScaleToolbox
           end
 
           def filtered_pricing_rule_methods
-            # looking up in metrics list does not work. Metric list includes methods and metrics
             result[:pricingrules].select { |limit| limit.dig('metric', 'type') == 'method' }
           end
         end

--- a/lib/3scale_toolbox/commands/plans_command/export/read_plan_metrics_step.rb
+++ b/lib/3scale_toolbox/commands/plans_command/export/read_plan_metrics_step.rb
@@ -26,7 +26,6 @@ module ThreeScaleToolbox
           end
 
           def filtered_limit_metrics
-            # looking up in metrics list does not work. Metric list includes methods and metrics
             result[:limits].select { |limit| limit.dig('metric', 'type') == 'metric' }
           end
 
@@ -39,7 +38,6 @@ module ThreeScaleToolbox
           end
 
           def filtered_pricing_rule_metrics
-            # looking up in metrics list does not work. Metric list includes methods and metrics
             result[:pricingrules].select { |limit| limit.dig('metric', 'type') == 'metric' }
           end
         end

--- a/lib/3scale_toolbox/commands/plans_command/export/step.rb
+++ b/lib/3scale_toolbox/commands/plans_command/export/step.rb
@@ -54,8 +54,6 @@ module ThreeScaleToolbox
           end
 
           def metric_info(elem, elem_name)
-            # Methods are included in metrics.
-            # First methods must be checked, otherwise it could be considered as a false metric
             if (method = find_method(elem.fetch('metric_id')))
               { 'type' => 'method', 'system_name' => method.fetch('system_name') }
             elsif (metric = find_metric(elem.fetch('metric_id')))

--- a/lib/3scale_toolbox/commands/plans_command/import/import_plan_metrics_step.rb
+++ b/lib/3scale_toolbox/commands/plans_command/import/import_plan_metrics_step.rb
@@ -18,9 +18,6 @@ module ThreeScaleToolbox
           private
 
           def missing_metrics
-            # service metrics list includes methods
-            # this array_difference method computes elements in resource_metrics not included in service_metrics
-            # So methods will not be in the "missing_metrics" list, as long as array diff semantics are kept.
             ThreeScaleToolbox::Helper.array_difference(resource_metrics, service_metrics) do |a, b|
               ThreeScaleToolbox::Helper.compare_hashes(a, b, ['system_name'])
             end

--- a/lib/3scale_toolbox/commands/plans_command/import/step.rb
+++ b/lib/3scale_toolbox/commands/plans_command/import/step.rb
@@ -81,6 +81,10 @@ module ThreeScaleToolbox
             context[:service_methods] ||= service.methods(service_hits['id'])
           end
 
+          def service_metrics_and_methods
+            service_metrics + service_methods
+          end
+
           def invalidate_service_methods
             context[:service_methods] = nil
           end
@@ -99,7 +103,7 @@ module ThreeScaleToolbox
           end
 
           def find_metric_by_system_name(system_name)
-            service_metrics.find { |metric| metric['system_name'] == system_name }
+            service_metrics_and_methods.find { |metric| metric['system_name'] == system_name }
           end
 
           private

--- a/lib/3scale_toolbox/entities/service.rb
+++ b/lib/3scale_toolbox/entities/service.rb
@@ -106,7 +106,7 @@ module ThreeScaleToolbox
       end
 
       def hits
-        hits_metric(metrics)
+        hits_metric(metrics_and_methods)
       end
 
       def methods(parent_metric_id)
@@ -116,6 +116,15 @@ module ThreeScaleToolbox
         end
 
         service_methods
+      end
+
+      def metrics_and_methods
+        m_m = remote.list_metrics id
+        if m_m.respond_to?(:has_key?) && (errors = m_m['errors'])
+          raise ThreeScaleToolbox::ThreeScaleApiError.new('Service metrics not read', errors)
+        end
+
+        m_m
       end
 
       def plans
@@ -242,6 +251,7 @@ module ThreeScaleToolbox
         end
       end
 
+
       private
 
       def hits_metric(metric_list)
@@ -249,15 +259,6 @@ module ThreeScaleToolbox
         raise ThreeScaleToolbox::Error, 'missing hits metric' if hits_metric.nil?
 
         hits_metric
-      end
-
-      def metrics_and_methods
-        metrics_and_methods = remote.list_metrics id
-        if metrics_and_methods.respond_to?(:has_key?) && (errors = metrics_and_methods['errors'])
-          raise ThreeScaleToolbox::ThreeScaleApiError.new('Service metrics not read', errors)
-        end
-
-        metrics_and_methods
       end
 
       def service_attrs

--- a/lib/3scale_toolbox/tasks/copy_limits_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_limits_task.rb
@@ -5,7 +5,6 @@ module ThreeScaleToolbox
       include Helper
 
       def call
-        metrics_map = metrics_mapping(source.metrics, target.metrics)
         plan_mapping = application_plan_mapping(source.plans, target.plans)
         plan_mapping.each do |plan_id, target_plan|
           source_plan = ThreeScaleToolbox::Entities::ApplicationPlan.new(id: plan_id, service: source)
@@ -21,6 +20,10 @@ module ThreeScaleToolbox
       end
 
       private
+
+      def metrics_map
+        @metrics_map ||= metrics_mapping(source_metrics_and_methods, target_metrics_and_methods)
+      end
 
       def missing_limits(source_limits, target_limits, metrics_map)
         ThreeScaleToolbox::Helper.array_difference(source_limits, target_limits) do |limit, target|

--- a/lib/3scale_toolbox/tasks/copy_mapping_rules_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_mapping_rules_task.rb
@@ -5,7 +5,6 @@ module ThreeScaleToolbox
       include Helper
 
       def call
-        metrics_map = metrics_mapping(source.metrics, target.metrics)
         missing_rules = missing_mapping_rules(source.mapping_rules,
                                               target.mapping_rules, metrics_map)
         missing_rules.each do |mapping_rule|
@@ -17,6 +16,10 @@ module ThreeScaleToolbox
       end
 
       private
+
+      def metrics_map
+        @metrics_map ||= metrics_mapping(source_metrics_and_methods, target_metrics_and_methods)
+      end
 
       def missing_mapping_rules(source_rules, target_rules, metrics_map)
         ThreeScaleToolbox::Helper.array_difference(source_rules, target_rules) do |source_rule, target_rule|

--- a/lib/3scale_toolbox/tasks/copy_metrics_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_metrics_task.rb
@@ -4,41 +4,27 @@ module ThreeScaleToolbox
       include CopyTask
 
       def call
-        source_metrics = source.metrics
-        target_metrics = target.metrics
-
         puts "original service has #{source_metrics.size} metrics"
         puts "target service has #{target_metrics.size} metrics"
-
-        missing = missing_metrics(source_metrics, target_metrics)
-
-        missing.each do |metric|
-          metric.delete('id')
-          metric.delete('links')
-          create_metric(metric)
-        end
-
-        puts "created #{missing.size} metrics on the target service"
+        missing_metrics.each(&method(:create_metric))
+        puts "created #{missing_metrics.size} metrics on the target service"
+        invalidate_target_metrics if missing_metrics.size.positive?
       end
 
       private
 
       def create_metric(metric)
-        Entities::Metric.create(service: target, attrs: metric)
+        new_metric = metric.reject { |key, _| %w[id links].include? key }
+        Entities::Metric.create(service: target, attrs: new_metric)
       rescue ThreeScaleToolbox::ThreeScaleApiError => e
-        raise e unless system_name_already_taken?(e.apierrors)
+        raise e unless ThreeScaleToolbox::Helper.system_name_already_taken_error?(e.apierrors)
 
         warn "[WARN] metric #{metric.fetch('system_name')} not created. " \
           'Method with the same system_name exists.'
       end
 
-      def system_name_already_taken?(error)
-        Array(Hash(error)['system_name']).any? { |msg| msg.match(/already been taken/) }
-      end
-
-      def missing_metrics(source_metrics, target_metrics)
-        ThreeScaleToolbox::Helper.array_difference(source_metrics,
-                                                   target_metrics) do |source, target|
+      def missing_metrics
+        @missing_metrics ||= ThreeScaleToolbox::Helper.array_difference(source_metrics, target_metrics) do |source, target|
           ThreeScaleToolbox::Helper.compare_hashes(source, target, ['system_name'])
         end
       end

--- a/lib/3scale_toolbox/tasks/copy_metrics_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_metrics_task.rb
@@ -13,14 +13,28 @@ module ThreeScaleToolbox
         missing = missing_metrics(source_metrics, target_metrics)
 
         missing.each do |metric|
+          metric.delete('id')
           metric.delete('links')
-          Entities::Metric.create(service: target, attrs: metric)
+          create_metric(metric)
         end
 
         puts "created #{missing.size} metrics on the target service"
       end
 
       private
+
+      def create_metric(metric)
+        Entities::Metric.create(service: target, attrs: metric)
+      rescue ThreeScaleToolbox::ThreeScaleApiError => e
+        raise e unless system_name_already_taken?(e.apierrors)
+
+        warn "[WARN] metric #{metric.fetch('system_name')} not created. " \
+          'Method with the same system_name exists.'
+      end
+
+      def system_name_already_taken?(error)
+        Array(Hash(error)['system_name']).any? { |msg| msg.match(/already been taken/) }
+      end
 
       def missing_metrics(source_metrics, target_metrics)
         ThreeScaleToolbox::Helper.array_difference(source_metrics,

--- a/lib/3scale_toolbox/tasks/copy_pricingrules_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_pricingrules_task.rb
@@ -5,7 +5,6 @@ module ThreeScaleToolbox
       include Helper
 
       def call
-        metrics_map = metrics_mapping(source.metrics, target.metrics)
         plan_mapping = application_plan_mapping(source.plans, target.plans)
         plan_mapping.each do |plan_id, target_plan|
           pricing_rules_source = source.remote.list_pricingrules_per_application_plan(plan_id)
@@ -26,6 +25,10 @@ module ThreeScaleToolbox
       end
 
       private
+
+      def metrics_map
+        @metrics_map ||= metrics_mapping(source_metrics_and_methods, target_metrics_and_methods)
+      end
 
       def missing_pricing_rules(source_pricing_rules, target_pricing_rules, metrics_map)
         ThreeScaleToolbox::Helper.array_difference(source_pricing_rules, target_pricing_rules) do |src, target|

--- a/lib/3scale_toolbox/tasks/copy_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_task.rb
@@ -21,6 +21,46 @@ module ThreeScaleToolbox
       def target
         context[:target]
       end
+
+      def source_metrics
+        context[:source_metrics] ||= source.metrics
+      end
+
+      def source_hits
+        context[:source_hits] ||= source.hits
+      end
+
+      def source_methods
+        context[:source_methods] ||= source.methods(source_hits.fetch('id'))
+      end
+
+      def source_metrics_and_methods
+        source_metrics + source_methods
+      end
+
+      def target_metrics
+        context[:target_metrics] ||= target.metrics
+      end
+
+      def target_hits
+        context[:target_hits] ||= target.hits
+      end
+
+      def target_methods
+        context[:target_methods] ||= target.methods(target_hits.fetch('id'))
+      end
+
+      def target_metrics_and_methods
+        target_metrics + target_methods
+      end
+
+      def invalidate_target_methods
+        context[:target_methods] = nil
+      end
+
+      def invalidate_target_metrics
+        context[:target_metrics] = nil
+      end
     end
   end
 end

--- a/spec/integration/commands/plans_command/plan_import_spec.rb
+++ b/spec/integration/commands/plans_command/plan_import_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe 'Application Plan Import' do
     expect(service_metrics).not_to be_empty
     service_methods = service.methods(service.hits.fetch('id'))
     expect(service_methods).not_to be_empty
+    service_all_metrics = service_metrics + service_methods
 
     remote_plan_client = ThreeScaleToolbox::Entities::ApplicationPlan.find(
       service: service, ref: file_plan['system_name']
@@ -59,7 +60,7 @@ RSpec.describe 'Application Plan Import' do
     ## compare limit read from remote and limit read from file
     expect(remote_plan_limit).to include(file_limit.clone.tap { |h| h.delete('metric_system_name') })
     ## check metric_id refer to a metric with metric_system_name from file limit
-    limit_metric = service_metrics.find do |m|
+    limit_metric = service_all_metrics.find do |m|
       m.fetch('id') == remote_plan_limit.fetch('metric_id')
     end
     expect(limit_metric).not_to be_nil
@@ -72,7 +73,7 @@ RSpec.describe 'Application Plan Import' do
     ## compare pricing rule read from remote and pricing rule read from file
     expect(remote_plan_pr).to include(file_pricingrule.clone.tap { |h| h.delete('metric_system_name') })
     ## check metric_id refer to a metric with metric_system_name from file pricing rule
-    pr_metric = service_metrics.find do |m|
+    pr_metric = service_all_metrics.find do |m|
       m.fetch('id') == remote_plan_pr.fetch('metric_id')
     end
     expect(pr_metric).not_to be_nil
@@ -88,6 +89,6 @@ RSpec.describe 'Application Plan Import' do
     expect(file_methods).to be_subset_of(service_methods).comparing_keys(file_method.keys)
 
     ## check imported metrics are subset of service metrics
-    expect(file_metrics).to be_subset_of(service_metrics).comparing_keys(file_metric.keys)
+    expect(file_metrics).to be_subset_of(service_all_metrics).comparing_keys(file_metric.keys)
   end
 end

--- a/spec/unit/commands/metrics_command/list_command_spec.rb
+++ b/spec/unit/commands/metrics_command/list_command_spec.rb
@@ -29,24 +29,10 @@ RSpec.describe ThreeScaleToolbox::Commands::MetricsCommand::List::ListSubcommand
       let(:hits_metric) { { 'id' => '0', 'friendly_name' => 'hits' } }
       let(:metric_1) { { 'id' => '1', 'friendly_name' => 'metric 1' } }
       let(:metric_2) { { 'id' => '2', 'friendly_name' => 'metric 2' } }
-      let(:method_0) { { 'id' => '3', 'friendly_name' => 'method 0' } }
-      let(:method_1) { { 'id' => '4', 'friendly_name' => 'method 1' } }
-      let(:methods) { [method_0, method_1] }
-      # metrics include methods
-      let(:metrics) { [hits_metric, metric_1, metric_2] + methods }
+      let(:metrics) { [hits_metric, metric_1, metric_2] }
 
       before :example do
-        expect(service).to receive(:hits).and_return(hits_metric)
         expect(service).to receive(:metrics).and_return(metrics)
-        expect(service).to receive(:methods).with(hits_metric['id']).and_return(methods)
-      end
-
-      it 'method_0 not in the list' do
-        expect { subject.run }.not_to output(/method 0/).to_stdout
-      end
-
-      it 'method_1 not in the list' do
-        expect { subject.run }.not_to output(/method 1/).to_stdout
       end
 
       it 'hits metric in the list' do

--- a/spec/unit/commands/plans_command/import/import_plan_limits_step_spec.rb
+++ b/spec/unit/commands/plans_command/import/import_plan_limits_step_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::ImportMetricLi
 
       before :example do
         expect(service).to receive(:metrics).and_return(service_metrics)
+        expect(service).to receive(:hits).and_return(service_metric)
       end
 
       it 'then limits are created' do

--- a/spec/unit/commands/plans_command/import/import_plan_pricing_rules_step_spec.rb
+++ b/spec/unit/commands/plans_command/import/import_plan_pricing_rules_step_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Import::ImportPricingR
 
       before :example do
         expect(service).to receive(:metrics).and_return(service_metrics)
+        expect(service).to receive(:hits).and_return(service_metric)
       end
 
       it 'then pricingrules are created' do

--- a/spec/unit/entities/service_spec.rb
+++ b/spec/unit/entities/service_spec.rb
@@ -177,7 +177,8 @@ RSpec.describe ThreeScaleToolbox::Entities::Service do
 
     context '#metrics' do
       it 'calls list_metrics method' do
-        expect(remote).to receive(:list_metrics).with(id).and_return(metrics)
+        expect(remote).to receive(:list_metrics).with(id).and_return(metrics + methods)
+        expect(remote).to receive(:list_methods).with(id, 1).and_return(methods)
         expect(subject.metrics).to eq(metrics)
       end
     end
@@ -189,7 +190,8 @@ RSpec.describe ThreeScaleToolbox::Entities::Service do
       end
 
       it 'return hits metric' do
-        expect(remote).to receive(:list_metrics).with(id).and_return(metrics)
+        expect(remote).to receive(:list_metrics).with(id).and_return(metrics + methods)
+        expect(remote).to receive(:list_methods).with(id, 1).and_return(methods)
         expect(subject.hits).to be(hits_metric)
       end
     end

--- a/spec/unit/entities/service_spec.rb
+++ b/spec/unit/entities/service_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe ThreeScaleToolbox::Entities::Service do
     end
 
     context '#metrics' do
-      it 'calls list_metrics method' do
+      it 'returns only metrics' do
         expect(remote).to receive(:list_metrics).with(id).and_return(metrics + methods)
         expect(remote).to receive(:list_methods).with(id, 1).and_return(methods)
         expect(subject.metrics).to eq(metrics)
@@ -191,7 +191,6 @@ RSpec.describe ThreeScaleToolbox::Entities::Service do
 
       it 'return hits metric' do
         expect(remote).to receive(:list_metrics).with(id).and_return(metrics + methods)
-        expect(remote).to receive(:list_methods).with(id, 1).and_return(methods)
         expect(subject.hits).to be(hits_metric)
       end
     end
@@ -200,6 +199,13 @@ RSpec.describe ThreeScaleToolbox::Entities::Service do
       it 'calls list_methods method' do
         expect(remote).to receive(:list_methods).with(id, hits_metric['id']).and_return(methods)
         expect(subject.methods(hits_metric['id'])).to eq(methods)
+      end
+    end
+
+    context '#metrics_and_methods' do
+      it 'calls list_metrics method' do
+        expect(remote).to receive(:list_metrics).with(id).and_return(metrics + methods)
+        expect(subject.metrics_and_methods).to eq(metrics + methods)
       end
     end
 

--- a/spec/unit/tasks/copy_limits_task_spec.rb
+++ b/spec/unit/tasks/copy_limits_task_spec.rb
@@ -30,18 +30,8 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyLimitsTask do
         'links' => []
       }
     end
+    let(:metric_hits) { { 'id' => 0, 'name' => 'hits', 'system_name' => 'hits' } }
     let(:metric_0) do
-      {
-        'id' => 0,
-        'name' => 'metric_0',
-        'system_name' => 'the_metric',
-        'unit': '1',
-        'created_at' => '2014-08-07T11:15:10+02:00',
-        'updated_at' => '2014-08-07T11:15:13+02:00',
-        'links' => []
-      }
-    end
-    let(:metric_1) do
       {
         'id' => 1,
         'name' => 'metric_1',
@@ -52,12 +42,34 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyLimitsTask do
         'links' => []
       }
     end
+    let(:metric_1) do
+      {
+        'id' => 2,
+        'name' => 'metric_1',
+        'system_name' => 'the_metric',
+        'unit': '1',
+        'created_at' => '2014-08-07T11:15:10+02:00',
+        'updated_at' => '2014-08-07T11:15:13+02:00',
+        'links' => []
+      }
+    end
     let(:limit_0) do
       { # limit for metric_0
-        'id' => 0,
+        'id' => 1,
         'period' => 'year',
         'value' => 10_000,
-        'metric_id' => 0,
+        'metric_id' => 1,
+        'created_at' => '2014-08-07T11:15:10+02:00',
+        'updated_at' => '2014-08-07T11:15:13+02:00',
+        'links' => []
+      }
+    end
+    let(:limit_1) do
+      { # limit for metric_1
+        'id' => 1,
+        'period' => 'year',
+        'value' => 10_000,
+        'metric_id' => 2,
         'created_at' => '2014-08-07T11:15:10+02:00',
         'updated_at' => '2014-08-07T11:15:13+02:00',
         'links' => []
@@ -72,9 +84,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyLimitsTask do
       allow(source).to receive(:remote).and_return(source_remote)
       allow(target).to receive(:remote).and_return(target_remote)
       expect(source).to receive(:plans).and_return(source_plans)
-      expect(source).to receive(:metrics).and_return(source_metrics)
       expect(target).to receive(:plans).and_return(target_plans)
-      expect(target).to receive(:metrics).and_return(target_metrics)
     end
 
     context 'no application plan match' do
@@ -87,75 +97,84 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyLimitsTask do
       end
     end
 
-    context 'no limit match' do
-      # missing limits set is empty
-      let(:source_limits) { [limit_0] }
+    context 'application plan match' do
       let(:target_plans) { [plan_0] }
-      let(:target_metrics) { [metric_0] }
-      let(:target_limits) { [limit_0] }
-
       before :each do
-        expect(source_remote).to receive(:list_application_plan_limits).with(0)
-                                                                       .and_return(source_limits)
-        expect(target_remote).to receive(:list_application_plan_limits).with(0)
-                                                                       .and_return(target_limits)
+        expect(source).to receive(:metrics).and_return([metric_0])
+        expect(source).to receive(:hits).and_return(metric_hits)
+        expect(source).to receive(:methods).and_return([])
+        expect(target).to receive(:metrics).and_return([metric_1])
+        expect(target).to receive(:hits).and_return(metric_hits)
+        expect(target).to receive(:methods).and_return([])
       end
 
-      it 'does not call create_application_plan_limit method' do
-        expect { subject.call }.to output(/Missing 0 plan limits/).to_stdout
-      end
-    end
+      context 'missing limits is empty' do
+        # missing limits set is empty
+        let(:source_limits) { [limit_0] }
+        let(:target_metrics) { [metric_0] }
+        let(:target_limits) { [limit_1] }
 
-    context '1 limit missing' do
-      let(:source_limits) { [limit_0] }
-      let(:target_plans) { [plan_0] }
-      let(:target_metrics) { [metric_1] }
-      let(:target_limits) { [] }
+        before :each do
+          expect(source_remote).to receive(:list_application_plan_limits).with(0)
+                                                                         .and_return(source_limits)
+          expect(target_remote).to receive(:list_application_plan_limits).with(0)
+                                                                         .and_return(target_limits)
+        end
 
-      before :each do
-        expect(source_remote).to receive(:list_application_plan_limits).with(0)
-                                                                       .and_return(source_limits)
-        expect(target_remote).to receive(:list_application_plan_limits).with(0)
-                                                                       .and_return(target_limits)
-      end
-
-      it 'calls create_application_plan_limit method' do
-        expect(target_remote).to receive(:create_application_plan_limit).with(plan_0['id'],
-                                                                              metric_1['id'],
-                                                                              limit_0)
-                                                                        .and_return({})
-        expect { subject.call }.to output(/Missing 1 plan limits/).to_stdout
-      end
-    end
-
-    context 'limit from diff metrics' do
-      let(:source_limits) { [limit_0] }
-      let(:target_plans) { [plan_0] }
-      let(:target_metrics) { [metric_1] }
-      let(:target_limit_0) do
-        { # limit for some other metric '2', same period
-          'id' => 0,
-          'period' => 'year',
-          'value' => 10_000,
-          'metric_id' => 2
-        }
-      end
-      # still missing limit_0 for metric_1
-      let(:target_limits) { [target_limit_0] }
-
-      before :each do
-        expect(source_remote).to receive(:list_application_plan_limits).with(0)
-                                                                       .and_return(source_limits)
-        expect(target_remote).to receive(:list_application_plan_limits).with(0)
-                                                                       .and_return(target_limits)
+        it 'does not call create_application_plan_limit method' do
+          expect { subject.call }.to output(/Missing 0 plan limits/).to_stdout
+        end
       end
 
-      it 'calls create_application_plan_limit method' do
-        expect(target_remote).to receive(:create_application_plan_limit).with(plan_0['id'],
-                                                                              metric_1['id'],
-                                                                              limit_0)
-                                                                        .and_return({})
-        expect { subject.call }.to output(/Missing 1 plan limits/).to_stdout
+      context '1 limit missing' do
+        let(:source_limits) { [limit_0] }
+        let(:target_metrics) { [metric_1] }
+        let(:target_limits) { [] }
+
+        before :each do
+          expect(source_remote).to receive(:list_application_plan_limits).with(0)
+                                                                         .and_return(source_limits)
+          expect(target_remote).to receive(:list_application_plan_limits).with(0)
+                                                                         .and_return(target_limits)
+        end
+
+        it 'calls create_application_plan_limit method' do
+          expect(target_remote).to receive(:create_application_plan_limit).with(plan_0['id'],
+                                                                                metric_1['id'],
+                                                                                limit_0)
+                                                                          .and_return({})
+          expect { subject.call }.to output(/Missing 1 plan limits/).to_stdout
+        end
+      end
+
+      context 'limit from diff metrics' do
+        let(:source_limits) { [limit_0] }
+        let(:target_metrics) { [metric_1] }
+        let(:target_limit_0) do
+          { # limit for some other metric '3', same period
+            'id' => 0,
+            'period' => 'year',
+            'value' => 10_000,
+            'metric_id' => 3
+          }
+        end
+        # still missing limit_0 for metric_1
+        let(:target_limits) { [target_limit_0] }
+
+        before :each do
+          expect(source_remote).to receive(:list_application_plan_limits).with(0)
+                                                                         .and_return(source_limits)
+          expect(target_remote).to receive(:list_application_plan_limits).with(0)
+                                                                         .and_return(target_limits)
+        end
+
+        it 'calls create_application_plan_limit method' do
+          expect(target_remote).to receive(:create_application_plan_limit).with(plan_0['id'],
+                                                                                metric_1['id'],
+                                                                                limit_0)
+                                                                          .and_return({})
+          expect { subject.call }.to output(/Missing 1 plan limits/).to_stdout
+        end
       end
     end
   end

--- a/spec/unit/tasks/copy_mapping_rules_task_spec.rb
+++ b/spec/unit/tasks/copy_mapping_rules_task_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyMappingRulesTask do
   context '#call' do
     let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
     let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
+    let(:metric_hits) { { 'id' => 99, 'name' => 'hits', 'system_name' => 'hits' } }
     let(:metric_0) do
       {
         'id' => 0,
@@ -67,10 +68,14 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyMappingRulesTask do
     subject { described_class.new(source: source, target: target) }
 
     before :each do
-      expect(source).to receive(:metrics).and_return(source_metrics)
       expect(source).to receive(:mapping_rules).and_return(source_mapping_rules)
-      expect(target).to receive(:metrics).and_return(target_metrics)
       expect(target).to receive(:mapping_rules).and_return(target_mapping_rules)
+      expect(source).to receive(:metrics).and_return(source_metrics)
+      expect(source).to receive(:hits).and_return(metric_hits)
+      expect(source).to receive(:methods).and_return([])
+      expect(target).to receive(:metrics).and_return(target_metrics)
+      expect(target).to receive(:hits).and_return(metric_hits)
+      expect(target).to receive(:methods).and_return([])
     end
 
     context 'no missing rules' do

--- a/spec/unit/tasks/copy_pricingrules_task_spec.rb
+++ b/spec/unit/tasks/copy_pricingrules_task_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyPricingRulesTask do
     let(:target_remote) { instance_double('ThreeScale::API::Client', 'target_remote') }
     let(:plan_0) { { 'id' => 0, 'name' => 'plan_0', 'system_name' => 'plan_0' } }
     let(:plan_1) { { 'id' => 1, 'name' => 'plan_1', 'system_name' => 'plan_1' } }
-    let(:metric_0) { { 'id' => 0, 'name' => 'metric_0', 'system_name' => 'metric_0' } }
-    let(:metric_1) { { 'id' => 1, 'name' => 'metric_0', 'system_name' => 'metric_0' } }
+    let(:metric_hits) { { 'id' => 0, 'name' => 'hits', 'system_name' => 'hits' } }
+    let(:metric_0) { { 'id' => 1, 'name' => 'metric_0', 'system_name' => 'metric_0' } }
+    let(:metric_1) { { 'id' => 2, 'name' => 'metric_0', 'system_name' => 'metric_0' } }
     let(:pricing_rule_0) do
       {
         'id' => 1,
@@ -15,7 +16,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyPricingRulesTask do
         'cost_per_unit' => '1.0',
         'min' => 1,
         'max' => 1000,
-        'metric_id' => 0
+        'metric_id' => 1
       }
     end
     let(:pricing_rule_1) do
@@ -25,7 +26,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyPricingRulesTask do
         'cost_per_unit' => '1.0',
         'min' => 1,
         'max' => 1000,
-        'metric_id' => 2
+        'metric_id' => 3
       }
     end
     let(:source_plans) { [plan_0] }
@@ -37,9 +38,7 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyPricingRulesTask do
       allow(source).to receive(:remote).and_return(source_remote)
       allow(target).to receive(:remote).and_return(target_remote)
       expect(source).to receive(:plans).and_return(source_plans)
-      expect(source).to receive(:metrics).and_return([metric_0])
       expect(target).to receive(:plans).and_return(target_plans)
-      expect(target).to receive(:metrics).and_return([metric_1])
     end
 
     context 'no application plan match' do
@@ -53,6 +52,12 @@ RSpec.describe ThreeScaleToolbox::Tasks::CopyPricingRulesTask do
 
     context 'application plans match' do
       before :each do
+        expect(source).to receive(:metrics).and_return([metric_0])
+        expect(source).to receive(:hits).and_return(metric_hits)
+        expect(source).to receive(:methods).and_return([])
+        expect(target).to receive(:metrics).and_return([metric_1])
+        expect(target).to receive(:hits).and_return(metric_hits)
+        expect(target).to receive(:methods).and_return([])
         expect(source_remote).to receive(:list_pricingrules_per_application_plan).and_return(source_pricingrules)
         expect(target_remote).to receive(:list_pricingrules_per_application_plan).and_return(target_pricingrules)
       end


### PR DESCRIPTION
`GET /admin/api/services/#{service_id}/metrics` returns metrics **AND** methods.
The command output regarding number of metrics was not accurate when copying because methods were included in the total result.

Issues came up in `3scale copy service` command when processing metrics and methods in a separate way (as it should). Scenarios before running copy command that could lead to issues:
* Destination service metric and source service method with same `system_name`
* Destination service method and source service metric with same `system_name`

In those initial scenarios, `3scale copy service` will output warning message and source metric/method will not be copied.

Signed-off-by: Eguzki Astiz Lezaun <eastizle@redhat.com>