### PR TITLE
Fix remote not found

### DIFF
--- a/lib/3scale_toolbox/remotes.rb
+++ b/lib/3scale_toolbox/remotes.rb
@@ -52,7 +52,7 @@ module ThreeScaleToolbox
     end
 
     def fetch(name)
-      all.fetch name
+      all.fetch(name) { raise_not_found(name) }
     end
 
     private

--- a/spec/unit/remotes_spec.rb
+++ b/spec/unit/remotes_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe ThreeScaleToolbox::Remotes do
     context 'non existing remote' do
       it 'raises error' do
         expect(config.data(:remotes)).not_to include('some_name')
-        expect { subject.fetch('some_name') }.to raise_error(KeyError)
+        expect { subject.fetch('some_name') }.to raise_error(ThreeScaleToolbox::Error, /not found/)
       end
     end
   end


### PR DESCRIPTION
Handle error when local remote does not exist, instead for raising `KeyError` error.

Signed-off-by: Eguzki Astiz Lezaun <eastizle@redhat.com>