### PR TITLE
create application plan: remove --end-user-required THREESCALE-2802

### DIFF
--- a/docs/app-plan.md
+++ b/docs/app-plan.md
@@ -35,7 +35,6 @@ OPTIONS
     -d --default                        Make default application plan
        --disabled                       Disables all methods and metrics in
                                         this application plan
-       --end-user-required=<value>      End user required. true or false
     -p --published                      Publish application plan
        --setup-fee=<value>              Setup fee
     -t --system-name=<value>            Application plan system name
@@ -85,7 +84,6 @@ OPTIONS
        --disabled                       Disables all methods and metrics in
                                         this application plan
        --enabled                        Enable application plan
-       --end-user-required=<value>      End user required. true or false
        --hide                           Hide application plan
     -n --name=<value>                   Plan name
     -p --publish                        Publish application plan

--- a/lib/3scale_toolbox/commands/plans_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/plans_command/apply_command.rb
@@ -22,7 +22,6 @@ module ThreeScaleToolbox
               option      nil, 'cost-per-month', 'Cost per month', argument: :required, transform: method(:Float)
               option      nil, 'setup-fee', 'Setup fee', argument: :required, transform: method(:Float)
               option      nil, 'trial-period-days', 'Trial period days', argument: :required, transform: method(:Integer)
-              option      nil, 'end-user-required', 'End user required. true or false', argument: :required, transform: ThreeScaleToolbox::Helper::BooleanTransformer.new
               param       :remote
               param       :service_ref
               param       :plan_ref
@@ -80,7 +79,6 @@ module ThreeScaleToolbox
             {
               'name' => options[:name],
               'approval_required' => options[:'approval-required'],
-              'end_user_required' => options[:'end-user-required'],
               'cost_per_month' => options[:'cost-per-month'],
               'setup_fee' => options[:'setup-fee'],
               'trial_period_days' => options[:'trial-period-days']

--- a/lib/3scale_toolbox/commands/plans_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/plans_command/create_command.rb
@@ -20,7 +20,6 @@ module ThreeScaleToolbox
               option      nil, 'cost-per-month', 'Cost per month', argument: :required, transform: method(:Float)
               option      nil, 'setup-fee', 'Setup fee', argument: :required, transform: method(:Float)
               option      nil, 'trial-period-days', 'Trial period days', argument: :required, transform: method(:Integer)
-              option      nil, 'end-user-required', 'End user required. true or false', argument: :required, transform: ThreeScaleToolbox::Helper::BooleanTransformer.new
               param       :remote
               param       :service_ref
               param       :plan_name
@@ -56,7 +55,6 @@ module ThreeScaleToolbox
               'name' => arguments[:plan_name],
               'system_name' => options[:'system-name'],
               'approval_required' => options[:'approval-required'],
-              'end_user_required' => options[:'end-user-required'],
               'cost_per_month' => options[:'cost-per-month'],
               'setup_fee' => options[:'setup-fee'],
               'trial_period_days' => options[:'trial-period-days']

--- a/spec/unit/commands/plans_command/apply_command_spec.rb
+++ b/spec/unit/commands/plans_command/apply_command_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Apply::ApplySubcommand
           let(:options) do
             {
               'approval-required': 'b',
-              'end-user-required': 'c',
               'cost-per-month': 0,
               'setup-fee': 1,
               'trial-period-days': 2
@@ -86,7 +85,6 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Apply::ApplySubcommand
           let(:plan_attrs) do
             {
               'approval_required' => 'b',
-              'end_user_required' => 'c',
               'cost_per_month' => 0,
               'setup_fee' => 1,
               'trial_period_days' => 2

--- a/spec/unit/commands/plans_command/create_command_spec.rb
+++ b/spec/unit/commands/plans_command/create_command_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Create::CreateSubcomma
           {
             'system_name' => 'a',
             'approval_required' => 'b',
-            'end_user_required' => 'c',
             'cost_per_month' => 0,
             'setup_fee' => 1,
             'trial_period_days' => 2


### PR DESCRIPTION
On premises does not allow creating application plan with `--end-user-required` set to `true`.

Error raised
```
Error: Application plan has not been created. Errors: {"end_user_required"=>["translation missing: en.activerecord.errors.models.application_plan.attributes.end_user_required.not_allowed"]}
```

Removed optional parameter from command.

Signed-off-by: Eguzki Astiz Lezaun <eastizle@redhat.com>