### PR TITLE
Make ProxyConfig promote command idempotent

### DIFF
--- a/spec/integration/commands/proxy_config_command/promote_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/promote_command_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'ProxyConfig Promote command' do
       end
 
       it "promotes the configuration version into production" do
-        expect { subject }.to output("Proxy Configuration promoted to '#{environment_prod}'\n").to_stdout
+        expect { subject }.to output("Proxy Configuration version 1 promoted to '#{environment_prod}'\n").to_stdout
         expect(subject).to eq(0)
       end
     end
@@ -40,9 +40,9 @@ RSpec.describe 'ProxyConfig Promote command' do
         res.delete if !res.nil?
       end
 
-      it "results in an error" do
-        expect { subject }.to output(/.*Error: ProxyConfig not promoted.*/).to_stderr
-        expect(subject).not_to eq(0)
+      it "results in not being promoted and a warning shown" do
+        expect { subject }.to output(/warning*/).to_stderr
+        expect(subject).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Related to issue https://github.com/3scale/3scale_toolbox/issues/173.

This PR shows a warning instead of returning an exit code different than 0 when a Staging ProxyConfig environment version has already been promoted to the Production environment.

The behavior now is:
 * If ProxyConfig staging for a service does not exist (has never been updated) an error is raised
 * If ProxyConfig production for a service does not exist, and promote is executed, the proxyconfiguration is promoted (it means the staging proxyconfiguration had never been promoted)
 * If ProxyConfig staging and production for a service are the same a warning is shown and an exit code 0 is returned (normal exit)
 * If ProxyConfig staging and production for a service are different the staging configuration is promoted to production

The output text shown in the CLI has been modified in both positive and negative outcomes to be a little more descriptive.

cc @nmasse-itix 