### PR TITLE
copy service: copy activedocs idempotent

### DIFF
--- a/lib/3scale_toolbox/commands/copy_command/copy_service.rb
+++ b/lib/3scale_toolbox/commands/copy_command/copy_service.rb
@@ -43,6 +43,11 @@ module ThreeScaleToolbox
                                                       service_params: create_service_attrs)
           end
 
+          if target_service == source_service
+            raise ThreeScaleToolbox::Error, 'Source and destination services are the same: ' \
+              "ID: #{source_service.id} system_name: #{source_service.attrs['system_name']}"
+          end
+
           puts "new service id #{target_service.id}"
 
           context = create_context(source_service, target_service)

--- a/lib/3scale_toolbox/entities/service.rb
+++ b/lib/3scale_toolbox/entities/service.rb
@@ -251,6 +251,9 @@ module ThreeScaleToolbox
         end
       end
 
+      def ==(other)
+        remote.http_client.endpoint == other.remote.http_client.endpoint && id == other.id
+      end
 
       private
 

--- a/lib/3scale_toolbox/tasks/copy_activedocs_task.rb
+++ b/lib/3scale_toolbox/tasks/copy_activedocs_task.rb
@@ -6,17 +6,35 @@ module ThreeScaleToolbox
       def call
         puts 'copying all service ActiveDocs'
 
-        target_activedocs = source.activedocs.map do |source_activedoc|
-          source_activedoc.clone.tap do |target_activedoc|
-            target_activedoc.delete('id')
-            target_activedoc['service_id'] = target.id
-            target_activedoc['system_name'] = "#{target_activedoc['system_name']}#{target.id}"
-          end
-        end
+        source.activedocs.each(&method(:apply_target_activedoc))
+      end
 
-        target_activedocs.each do |ad|
-          res = target.remote.create_activedocs(ad)
-          raise ThreeScaleToolbox::Error, "ActiveDocs has not been created. Errors: #{res['errors']}" unless res['errors'].nil?
+      private
+
+      def apply_target_activedoc(attrs)
+        activedocs = Entities::ActiveDocs.find_by_system_name(remote: target.remote,
+                                                              system_name: attrs['system_name'])
+        if activedocs.nil?
+          Entities::ActiveDocs.create(remote: target.remote, attrs: create_attrs(attrs))
+        elsif activedocs.attrs.fetch('service_id') == target.id
+          activedocs.update(update_attrs(attrs))
+        else
+          # activedocs with same system_name exists, but now owned by target service
+          new_attrs = create_attrs(attrs)
+          new_attrs['system_name'] = "#{attrs['system_name']}#{target.id}"
+          Entities::ActiveDocs.create(remote: target.remote, attrs: new_attrs)
+        end
+      end
+
+      def update_attrs(old_attrs)
+        create_attrs(old_attrs)
+      end
+
+      def create_attrs(old_attrs)
+        # keep same system_name
+        new_attrs = old_attrs.reject { |key, _| %w[id created_at updated_at].include? key }
+        new_attrs.tap do |attrs|
+          attrs['service_id'] = target.id
         end
       end
     end

--- a/spec/unit/commands/copy_command/service_spec.rb
+++ b/spec/unit/commands/copy_command/service_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe ThreeScaleToolbox::Commands::CopyCommand::CopyServiceSubcommand d
                                                               'system_name' => source_system_name)
     end
 
+    context 'when source and target service are the same' do
+      before :example do
+        expect(service_class).to receive(:find).with(remote: target_remote, ref: source_system_name)
+                                               .and_return(source_service_obj)
+        expect(source_service_obj).to receive(:id).and_return(1)
+      end
+
+      it 'error raised' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error, /Source and destination services are the same/)
+      end
+    end
+
     context 'when target service exists' do
       before :example do
         expect(service_class).to receive(:find).with(remote: target_remote, ref: source_system_name)

--- a/spec/unit/entities/service_spec.rb
+++ b/spec/unit/entities/service_spec.rb
@@ -443,6 +443,66 @@ RSpec.describe ThreeScaleToolbox::Entities::Service do
           end
         end
       end
+
+      context 'equality method' do
+        let(:svc1) { described_class.new(id: id1, remote: remote1) }
+        let(:svc2) { described_class.new(id: id2, remote: remote2) }
+        let(:remote1) { instance_double(ThreeScale::API::Client, 'remote1') }
+        let(:remote2) { instance_double(ThreeScale::API::Client, 'remote2') }
+        let(:http_client1) { instance_double(ThreeScale::API::HttpClient, 'httpclient1') }
+        let(:http_client2) { instance_double(ThreeScale::API::HttpClient, 'httpclient2') }
+
+        before :example do
+          allow(remote1).to receive(:http_client).and_return(http_client1)
+          allow(remote2).to receive(:http_client).and_return(http_client2)
+          allow(http_client1).to receive(:endpoint).and_return(endpoint1)
+          allow(http_client2).to receive(:endpoint).and_return(endpoint2)
+        end
+
+        context 'same remote, diff id' do
+          let(:id1) { 1 }
+          let(:id2) { 2 }
+          let(:endpoint1) { 'https://w1.example.com' }
+          let(:endpoint2) { 'https://w1.example.com' }
+
+          it 'are not equal' do
+            expect(svc1).not_to eq(svc2)
+          end
+        end
+
+        context 'same remote, same id' do
+          let(:id1) { 1 }
+          let(:id2) { 1 }
+          let(:endpoint1) { 'https://w1.example.com' }
+          let(:endpoint2) { 'https://w1.example.com' }
+
+          it 'are equal' do
+            expect(svc1).to eq(svc2)
+          end
+        end
+
+        context 'diff remote, same id' do
+          let(:id1) { 1 }
+          let(:id2) { 1 }
+          let(:endpoint1) { 'https://w1.example.com' }
+          let(:endpoint2) { 'https://w2.example.com' }
+
+          it 'are not equal' do
+            expect(svc1).not_to eq(svc2)
+          end
+        end
+
+        context 'diff remote, diff id' do
+          let(:id1) { 1 }
+          let(:id2) { 2 }
+          let(:endpoint1) { 'https://w1.example.com' }
+          let(:endpoint2) { 'https://w2.example.com' }
+
+          it 'are not equal' do
+            expect(svc1).not_to eq(svc2)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/unit/tasks/copy_activedocs_spec.rb
+++ b/spec/unit/tasks/copy_activedocs_spec.rb
@@ -1,56 +1,83 @@
 RSpec.describe ThreeScaleToolbox::Tasks::CopyActiveDocsTask do
   context '#call' do
-    let(:source_service_id) { '10' }
-    let(:target_service_id) { '20' }
-    let(:source) { instance_double('ThreeScaleToolbox::Entities::Service', 'source') }
-    let(:target) { instance_double('ThreeScaleToolbox::Entities::Service', 'target') }
-    let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
+    let(:source_service_id) { 10 }
+    let(:target_service_id) { 20 }
+    let(:source) { instance_double(ThreeScaleToolbox::Entities::Service, 'source') }
+    let(:target) { instance_double(ThreeScaleToolbox::Entities::Service, 'target') }
+    let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
+    let(:activedocs_class) { class_double(ThreeScaleToolbox::Entities::ActiveDocs).as_stubbed_const }
     let(:activedocs0) do
       {
         'id' => 0, 'name' => 'ad_0', 'system_name' => 'ad_0', 'service_id' => source_service_id
       }
     end
-    let(:activedocs1) do
-      {
-        'id' => 1, 'name' => 'ad_1', 'system_name' => 'ad_1', 'service_id' => source_service_id
-      }
-    end
-    let(:activedocs) { [activedocs0, activedocs1] }
+    let(:activedocs) { [activedocs0] }
 
     subject { described_class.new(source: source, target: target) }
 
-    before :each do
+    before :example do
       expect(source).to receive(:activedocs).and_return(activedocs)
-      allow(target).to receive(:id).and_return(target_service_id)
       allow(target).to receive(:remote).and_return(remote)
+      allow(target).to receive(:id).and_return(target_service_id)
+      expect(activedocs_class).to receive(:find_by_system_name).with(remote: remote,
+                                                                     system_name: 'ad_0')
+                                                               .and_return(target_activedoc)
     end
 
-    it 'creates all activedocs' do
-      expect(remote).to receive(:create_activedocs).exactly(activedocs.size).times.and_return({})
-      subject.call
-    end
-
-    it 'creates activedocs with target service id' do
-      activedocs.each do
-        expect(remote).to receive(:create_activedocs).with(
-          hash_including('service_id' => target_service_id)
-        ).and_return({})
+    context 'target activedocs not found' do
+      let(:target_activedoc) { nil }
+      let(:expected_create_attrs) do
+        { 'name' => 'ad_0', 'system_name' => 'ad_0', 'service_id' => target_service_id }
       end
-      subject.call
-    end
 
-    it 'creates activedocs with updated system_nameid' do
-      activedocs.each do |ad|
-        expect(remote).to receive(:create_activedocs).with(
-          hash_including('system_name' => "#{ad['system_name']}#{target_service_id}")
-        ).and_return({})
+      it 'activedocs created' do
+        expect(activedocs_class).to receive(:create).with(remote: remote,
+                                                          attrs: expected_create_attrs)
+                                                    .and_return(activedocs)
+        subject.call
       end
-      subject.call
     end
 
-    it 'raises error when create failed' do
-      expect(remote).to receive(:create_activedocs).and_return('errors' => 'some error')
-      expect { subject.call }.to raise_error(ThreeScaleToolbox::Error)
+    context 'target activedocs found' do
+      let(:target_activedoc) do
+        instance_double(ThreeScaleToolbox::Entities::ActiveDocs, 'target_activedocs')
+      end
+
+      let(:target_attrs) do
+        { 'name' => 'target_ad_0', 'system_name' => 'ad_0', 'service_id' => target_ad_service_id }
+      end
+
+      before :example do
+        expect(target_activedoc).to receive(:attrs).and_return(target_attrs)
+      end
+
+      context 'activedocs owned by target service' do
+        let(:target_ad_service_id) { target_service_id }
+
+        let(:expected_update_attrs) do
+          { 'name' => 'ad_0', 'system_name' => 'ad_0', 'service_id' => target_service_id }
+        end
+
+        it 'activedocs updated' do
+          expect(target_activedoc).to receive(:update).with(expected_update_attrs)
+          subject.call
+        end
+      end
+
+      context 'activedocs not owned by target service' do
+        let(:target_ad_service_id) { target_service_id + 10 }
+
+        let(:expected_create_attrs) do
+          { 'name' => 'ad_0', 'system_name' => "ad_0#{target_service_id}", 'service_id' => target_service_id }
+        end
+
+        it 'activedocs created' do
+          expect(activedocs_class).to receive(:create).with(remote: remote,
+                                                            attrs: expected_create_attrs)
+                                                      .and_return(activedocs)
+          subject.call
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Activedocs copy is idempotent. Will update if already exists and create if it does not.

Additionally, added check to `copy service` in case source and target service are the same service