### PR TITLE
Test wait method to retry until timeout

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -174,4 +174,21 @@ module Helpers
       end
     end
   end
+
+  # wait tries a block of code until it returns true, or the timeout is reached.
+  # timeout give an upper limit to the amount of time this method will run
+  # Some intervals may be missed if the block takes too long or the time window is too short.
+  def self.wait(interval = 0.5, timeout = 30)
+    raise 'wait expects block' unless block_given?
+
+    end_time = Time.now + timeout
+    until Time.now > end_time
+      result = yield
+      return if result == true
+
+      sleep interval
+    end
+
+    raise "timed out after #{timeout} seconds"
+  end
 end

--- a/spec/integration/commands/proxy_config_command/list_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/list_command_spec.rb
@@ -13,11 +13,20 @@ RSpec.describe 'ProxyConfig List command' do
       svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
 
       svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage1" })
-      pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)
+      pc_sandbox_1 = nil
+      Helpers.wait do
+        pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)
+        !pc_sandbox_1.nil? 
+      end
+
       pc_sandbox_1.promote(to: "production")
 
       svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage2" })
-      pc_sandbox_2 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 2)
+      pc_sandbox_2 = nil
+      Helpers.wait do
+        pc_sandbox_2 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 2)
+        !pc_sandbox_2.nil? 
+      end
       pc_sandbox_2.promote(to: "production")
 
       svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage3" })

--- a/spec/integration/commands/proxy_config_command/promote_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/promote_command_spec.rb
@@ -31,7 +31,11 @@ RSpec.describe 'ProxyConfig Promote command' do
       before :example do
         svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
         svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage1" })
-        pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)
+        pc_sandbox_1 = nil
+        Helpers.wait do
+          pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)
+          !pc_sandbox_1.nil? 
+        end
         pc_sandbox_1.promote(to: environment_prod)
       end
 

--- a/spec/integration/commands/proxy_config_command/show_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/show_command_spec.rb
@@ -13,11 +13,19 @@ RSpec.describe 'ProxyConfig Show command' do
       svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
 
       svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage1" })
-      pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)
+      pc_sandbox_1 = nil
+      Helpers.wait do
+        pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)
+        !pc_sandbox_1.nil?
+      end
       pc_sandbox_1.promote(to: "production")
 
       svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage2" })
-      pc_sandbox_2 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 2)
+      pc_sandbox_2 = nil
+      Helpers.wait do
+        pc_sandbox_2 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 2)
+        !pc_sandbox_2.nil?
+      end
       pc_sandbox_2.promote(to: "production")
 
       svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage3" })
@@ -43,7 +51,7 @@ RSpec.describe 'ProxyConfig Show command' do
           expect(subject).to eq(0)
         end
       end
-      
+
       context "specifying a config-version" do
         let(:config_version) { 2 }
         let(:expected_config_version) { config_version }
@@ -92,5 +100,5 @@ RSpec.describe 'ProxyConfig Show command' do
         end
       end
     end
-  end  
+  end
 end


### PR DESCRIPTION
Integration tests show random failures when proxy config is updated.

This is because proxy config version is not updated synchronously when API is called. If the system is not fast enough creating new proxy version, then trying to promote the new version fails randomly.

Added helper function to retry until timeout is reached. This helper method will make sure 3scale API has time enough to create new proxy config version and be promoted.