### PR TITLE
Fix documentation on evaluation order of application parameter

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -78,23 +78,21 @@ DESCRIPTION
 
     Application param allows:
 
-    * Application internal id
-
     * User_key (API key)
 
-    * App_id (from app_id/app_key pair)
+    * App_id (from app_id/app_key pair) or Client ID (for OAuth and OpenID
+    Connect authentication modes)
 
-    * Client ID (for OAuth and OpenID Connect authentication modes)
+    * Application internal id
 ```
 
 ### Apply
 
 * Update (create if it does not exist) application.
 * `application` positional argument is application unique identifier. Allowed id's are:
-  * Application internal id
   * User_key (API key)
-  * App_id (from app_id/app_key pair)
-  * Client ID (for OAuth and OpenID Connect authentication modes)
+  * App_id (from app_id/app_key pair) or Client ID (for OAuth and OpenID Connect authentication modes)
+  * Application internal id
 * `account` optional argument is required when application is not found and needs to be created. It can be one of the following and the toolbox will figure it out:
   * Account `id`
   * `username`, `email` or `user_id` of the admin user of the account 
@@ -118,13 +116,12 @@ DESCRIPTION
 
     Application param allows:
 
-    * Application internal id
-
     * User_key (API key)
 
-    * App_id (from app_id/app_key pair)
+    * App_id (from app_id/app_key pair) or Client ID (for OAuth and OpenID
+    Connect authentication modes)
 
-    * Client ID (for OAuth and OpenID Connect authentication modes)
+    * Application internal id
 
 OPTIONS
        --account=<value>              Application's account. Required when
@@ -151,10 +148,9 @@ OPTIONS
 ### Delete
 
 * `application` positional argument is application unique identifier. Allowed id's are:
-  * Application internal id
   * User_key (API key)
-  * App_id (from app_id/app_key pair)
-  * Client ID (for OAuth and OpenID Connect authentication modes)
+  * App_id (from app_id/app_key pair) or Client ID (for OAuth and OpenID Connect authentication modes)
+  * Application internal id
 
 ```shell
 NAME
@@ -169,11 +165,10 @@ DESCRIPTION
 
     Application param allows:
 
-    * Application internal id
-
     * User_key (API key)
 
-    * App_id (from app_id/app_key pair)
+    * App_id (from app_id/app_key pair) or Client ID (for OAuth and OpenID
+    Connect authentication modes)
 
-    * Client ID (for OAuth and OpenID Connect authentication modes)
+    * Application internal id
 ```

--- a/lib/3scale_toolbox/commands/application_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/apply_command.rb
@@ -13,10 +13,9 @@ module ThreeScaleToolbox
               description <<-HEREDOC
               Update (create if it does not exist) application'
               \n Application param allows:
-              \n * Application internal id
               \n * User_key (API key)
-              \n * App_id (from app_id/app_key pair)
-              \n * Client ID (for OAuth and OpenID Connect authentication modes)
+              \n * App_id (from app_id/app_key pair) or Client ID (for OAuth and OpenID Connect authentication modes)
+              \n * Application internal id
               HEREDOC
 
               option      nil, 'user-key', 'User Key (API Key) of the application to be created.', argument: :required

--- a/lib/3scale_toolbox/commands/application_command/delete_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/delete_command.rb
@@ -13,10 +13,9 @@ module ThreeScaleToolbox
               description <<-HEREDOC
               Delete application'
               \n Application param allows:
-              \n * Application internal id
               \n * User_key (API key)
-              \n * App_id (from app_id/app_key pair)
-              \n * Client ID (for OAuth and OpenID Connect authentication modes)
+              \n * App_id (from app_id/app_key pair) or Client ID (for OAuth and OpenID Connect authentication modes)
+              \n * Application internal id
               HEREDOC
 
               param       :remote

--- a/lib/3scale_toolbox/commands/application_command/show_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/show_command.rb
@@ -16,10 +16,9 @@ module ThreeScaleToolbox
               description <<-HEREDOC
               Show application attributes
               \n Application param allows:
-              \n * Application internal id
               \n * User_key (API key)
-              \n * App_id (from app_id/app_key pair)
-              \n * Client ID (for OAuth and OpenID Connect authentication modes)
+              \n * App_id (from app_id/app_key pair) or Client ID (for OAuth and OpenID Connect authentication modes)
+              \n * Application internal id
               HEREDOC
 
               param       :remote

--- a/lib/3scale_toolbox/entities/application.rb
+++ b/lib/3scale_toolbox/entities/application.rb
@@ -12,10 +12,9 @@ module ThreeScaleToolbox
         end
 
         # ref can be
-        # * Application internal id
         # * User_key (API key)
-        # * App_id (from app_id/app_key pair)
-        # * Client ID (for OAuth and OpenID Connect authentication modes)
+        # * App_id (from app_id/app_key pair) / Client ID (for OAuth and OpenID Connect authentication modes)
+        # * Application internal id
         def find(remote:, service_id: nil, ref:)
           app = find_by_user_key(remote, service_id, ref)
           return app unless app.nil?


### PR DESCRIPTION
Fix application command documentation to reflect the current criteria order on how an application is found in the toolbox application command