### PR TITLE
Mark update supercommand as deprecated in main help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ COMMANDS
     proxy-config         proxy-config super command
     remote               remotes super command
     service              services super command
-    update               update super command
+    update               [DEPRECTATED] update super command
 
 OPTIONS
     -c --config-file=<value>      3scale toolbox configuration file (default:

--- a/lib/3scale_toolbox/commands/update_command.rb
+++ b/lib/3scale_toolbox/commands/update_command.rb
@@ -8,7 +8,7 @@ module ThreeScaleToolbox
         Cri::Command.define do
           name        'update'
           usage       'update <sub-command> [options]'
-          summary     'update super command'
+          summary     '[DEPRECTATED] update super command'
           description 'Update 3scale entities between tenants'
 
           run do |_opts, _args, cmd|


### PR DESCRIPTION
The main help message in toolbox now is shown as:

```
msoriano@localhost:~/repositories/3scale_toolbox (mark-update-service-deprecated)$ bundle exec 3scale --help
NAME
    3scale - 3scale toolbox

USAGE
    3scale <sub-command> [options]

DESCRIPTION
    3scale toolbox to manage your API from the terminal.

COMMANDS
    account              account super command
    activedocs           activedocs super command
    application          application super command
    application-plan     application-plan super command
    copy                 copy super command
    help                 show help
    import               import super command
    method               method super command
    metric               metric super command
    policy-registry      policy-registry super command
    proxy-config         proxy-config super command
    remote               remotes super command
    service              services super command
    update               [DEPRECTATED] update super command

OPTIONS
    -c --config-file=<value>      3scale toolbox configuration file (default:
                                  /home/msoriano/.3scalerc.yaml)
    -h --help                     show help for this command
    -k --insecure                 Proceed and operate even for server
                                  connections otherwise considered insecure
    -v --version                  Prints the version of this command
       --verbose                  Verbose mode
```