### PR TITLE
CVE-2019-16892: rubyzip >= 1.3.0 THREESCALE-3731

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ gemspec
 group :development do
   gem 'license_finder', '~> 5.5'
   gem 'pry'
+  # rubyzip is a transitive depencency from license_finder with vulnerability on < 1.3.0
+  gem 'rubyzip', '>= 1.3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    rubyzip (1.2.4)
+    rubyzip (2.0.0)
     safe_yaml (1.0.5)
     thor (0.20.3)
     toml (0.2.0)
@@ -71,6 +71,7 @@ DEPENDENCIES
   pry
   rake (~> 10.0)
   rspec (~> 3.8)
+  rubyzip (>= 1.3.0)
   webmock (~> 3.4)
 
 BUNDLED WITH


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2019-16892

The library affected by the vulnerability issue is a transitive (not direct) dependency on the "development" library `license-finder`. Development library are libraries used in dev-testing and are not included in releases. Hence, it does not affect packaged releases.