### PR TITLE
Add custom host header and secret token options for import openapi

### DIFF
--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -37,6 +37,8 @@ module ThreeScaleToolbox
               option  nil, 'staging-public-base-url', 'Custom public staging URL', argument: :required
               option  nil, 'production-public-base-url', 'Custom public production URL', argument: :required
               option  nil, 'override-private-base-url', 'Custom private base URL', argument: :required
+              option nil, 'backend-api-secret-token', 'Custom secret token sent by the API gateway to the backend API',argument: :required
+              option nil, 'backend-api-host-header', 'Custom host header sent by the API gateway to the backend API', argument: :required
               param   :openapi_resource
 
               runner OpenAPISubcommand
@@ -83,6 +85,8 @@ module ThreeScaleToolbox
               production_public_base_url: options[:'production-public-base-url'],
               staging_public_base_url: options[:'staging-public-base-url'],
               override_private_base_url: options[:'override-private-base-url'],
+              backend_api_secret_token: options[:'backend-api-secret-token'],
+              backend_api_host_header: options[:'backend-api-host-header'],
             }
           end
 

--- a/lib/3scale_toolbox/commands/import_command/openapi/step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/step.rb
@@ -70,6 +70,14 @@ module ThreeScaleToolbox
           def override_private_base_url
             context[:override_private_base_url]
           end
+
+          def backend_api_secret_token
+            context[:backend_api_secret_token]
+          end
+
+          def backend_api_host_header
+            context[:backend_api_host_header]
+          end
         end
       end
     end

--- a/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
@@ -40,9 +40,9 @@ module ThreeScaleToolbox
           end
 
           def add_api_backend_settings(settings)
-            return if private_base_url.nil?
-
-            settings[:api_backend] = private_base_url
+            settings[:api_backend] = private_base_url if !private_base_url.nil?
+            settings[:secret_token] = backend_api_secret_token if !backend_api_secret_token.nil?
+            settings[:hostname_rewrite] = backend_api_host_header if !backend_api_host_header.nil?
           end
 
           def add_security_proxy_settings(settings)

--- a/spec/integration/commands/import_command/openapi/backend_api_spec.rb
+++ b/spec/integration/commands/import_command/openapi/backend_api_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe 'OpenAPI import backend api related parameters test' do
+  include_context :oas_common_context
+
+  let(:expected_backend_api_secret_token) { "secret_token" }
+  let(:expected_backend_api_hostname_rewrite) { "backendapihost.com" }
+  let(:oas_resource_path) { File.join(resources_path, 'petstore.yaml') }
+  let(:command_line_str) do
+    "import openapi -t #{system_name} -d #{destination_url}" \
+    " --backend-api-secret-token=#{expected_backend_api_secret_token}" \
+    " --backend-api-host-header=#{expected_backend_api_hostname_rewrite}" \
+    " #{oas_resource_path}"
+  end
+
+  it 'expected backend api configuration options are set' do
+    expect { subject }.to output.to_stdout
+    expect(subject).to eq(0)
+
+    expect(service_proxy).to include(
+      'secret_token' => expected_backend_api_secret_token,
+      'hostname_rewrite' => expected_backend_api_hostname_rewrite,
+    )
+  end
+end

--- a/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
   let(:staging_public_base_url) { nil }
   let(:override_private_base_url) { nil }
   let(:oidc_issuer_endpoint) { 'https://sso.example.com' }
+  let(:backend_api_secret_token) { nil }
+  let(:backend_api_host_header) { nil }
+
   let(:openapi_context) do
     {
       target: service,
@@ -16,6 +19,8 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
       production_public_base_url: production_public_base_url,
       staging_public_base_url: staging_public_base_url,
       override_private_base_url: override_private_base_url,
+      backend_api_secret_token:backend_api_secret_token,
+      backend_api_host_header: backend_api_host_header,
     }
   end
 
@@ -61,6 +66,26 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
       it 'api_backend updated' do
         expect(service).to receive(:update_proxy)
           .with(hash_including(api_backend: 'https://example.com')).and_return({})
+        expect { subject }.to output.to_stdout
+      end
+    end
+
+    context 'backend api host header set' do
+      let(:backend_api_host_header) { 'example.com'}
+
+      it 'hostname_rewrite updated' do
+        expect(service).to receive(:update_proxy)
+          .with(hash_including(hostname_rewrite: backend_api_host_header)).and_return({})
+        expect { subject }.to output.to_stdout
+      end
+    end
+
+    context 'backend api secret token set' do
+      let(:backend_api_secret_token) { 'secret_token'}
+
+      it 'secret_token updated' do
+        expect(service).to receive(:update_proxy)
+          .with(hash_including(secret_token: backend_api_secret_token)).and_return({})
         expect { subject }.to output.to_stdout
       end
     end


### PR DESCRIPTION
Add new options in the import openapi command to allow specifying
a custom host header and a secret token that the API gateway will
send to the configured backend API in the proxy configuration.