### PR TITLE
Add prefix matching flag for mapping rules in import openapi command

### DIFF
--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -30,6 +30,7 @@ module ThreeScaleToolbox
               option  :t, 'target_system_name', 'Target system name', argument: :required
               flag    nil, 'activedocs-hidden', 'Create ActiveDocs in hidden state'
               flag    nil, 'skip-openapi-validation', 'Skip OpenAPI schema validation'
+              flag    nil, 'prefix-matching', 'Use prefix matching instead of strict matching on mapping rules derived from openapi operations'
               option  nil, 'oidc-issuer-endpoint', 'OIDC Issuer Endpoint', argument: :required
               option  nil, 'default-credentials-userkey', 'Default credentials policy userkey', argument: :required
               option  nil, 'override-private-basepath', 'Override the basepath for the private URLs', argument: :required
@@ -74,7 +75,7 @@ module ThreeScaleToolbox
             openapi_resource = load_resource(arguments[:openapi_resource])
             {
               api_spec_resource: openapi_resource,
-              api_spec: ThreeScaleApiSpec.new(load_openapi(openapi_resource), options[:'override-public-basepath']),
+              api_spec: ThreeScaleApiSpec.new(load_openapi(openapi_resource), options[:'override-public-basepath'], options[:'prefix-matching']),
               threescale_client: threescale_client(fetch_required_option(:destination)),
               target_system_name: options[:target_system_name],
               activedocs_published: !options[:'activedocs-hidden'],

--- a/lib/3scale_toolbox/commands/import_command/openapi/mapping_rule.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/mapping_rule.rb
@@ -17,8 +17,9 @@ module ThreeScaleToolbox
           end
 
           def pattern
-            # apply strict matching
-            "#{raw_pattern}$"
+            res = "#{raw_pattern}"
+            res = "#{res}$" if !operation[:prefix_matching] # apply strict matching
+            res
           end
 
           def raw_pattern

--- a/lib/3scale_toolbox/commands/import_command/openapi/threescale_api_spec.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/threescale_api_spec.rb
@@ -4,10 +4,12 @@ module ThreeScaleToolbox
       module OpenAPI
         class ThreeScaleApiSpec
           attr_reader :openapi
+          attr_reader :prefix_matching
 
-          def initialize(openapi, base_path = nil)
+          def initialize(openapi, base_path = nil, prefix_matching = false)
             @openapi = openapi
             @base_path = base_path
+            @prefix_matching = prefix_matching
           end
 
           def title
@@ -53,6 +55,7 @@ module ThreeScaleToolbox
                 verb: op.verb,
                 operationId: op.operation_id,
                 description: op.description,
+                prefix_matching: prefix_matching,
               )
             end
           end

--- a/spec/integration/commands/import_command/openapi/prefix_matching_spec.rb
+++ b/spec/integration/commands/import_command/openapi/prefix_matching_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe 'OpenAPI prefix matching test' do
+  include_context :oas_common_context
+
+  let(:oas_resource_path) { File.join(resources_path, 'petstore.yaml') }
+  let(:command_line_str) do
+    "import openapi -t #{system_name} -d #{destination_url}" \
+    " --prefix-matching" \
+    " #{oas_resource_path}"
+  end
+
+  let(:mapping_rule_keys) { %w[pattern http_method delta] }
+
+  let(:expected_mapping_rules) do
+    [
+      { 'pattern' => '/v2/pet', 'http_method' => 'POST', 'delta' => 1 },
+      { 'pattern' => '/v2/pet', 'http_method' => 'PUT', 'delta' => 1 },
+      { 'pattern' => '/v2/pet/findByStatus', 'http_method' => 'GET', 'delta' => 1 }
+    ]
+  end
+
+  it 'Mapping rules patterns set with prefix matching' do
+    expect { subject }.to output.to_stdout
+    expect(subject).to eq(0)
+
+    # mapping rules are created
+    expect(expected_mapping_rules.size).to be > 0
+    # expect Set(service.mapping_rules) == Set(expected_mapping_rules)
+    # with a custom identity method for mapping_rules
+    expect(expected_mapping_rules).to be_subset_of(service.mapping_rules).comparing_keys(mapping_rule_keys)
+    expect(service.mapping_rules).to be_subset_of(expected_mapping_rules).comparing_keys(mapping_rule_keys)
+  end
+end

--- a/spec/unit/commands/import_command/openapi/mapping_rule_spec.rb
+++ b/spec/unit/commands/import_command/openapi/mapping_rule_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe 'OpenAPI Mapping Rule' do
     let(:path) { '/some/path' }
     let(:metric_id) { '1' }
     let(:public_base_path) { '/v1' }
+    let(:prefix_matching) { false }
     let(:operation) do
-      { verb: verb, path: path, metric_id: metric_id, public_base_path: public_base_path }
+      { verb: verb, path: path, metric_id: metric_id, public_base_path: public_base_path, prefix_matching: prefix_matching }
     end
     subject { OpenAPIMappingRuleClass.new(operation).mapping_rule }
 
@@ -39,6 +40,13 @@ RSpec.describe 'OpenAPI Mapping Rule' do
       let(:public_base_path) { '/v1/' }
       it 'pattern removes last /' do
         is_expected.to include('pattern' => '/v1/some/path$')
+      end
+    end
+
+    context 'with prefix_matching enabled' do
+      let(:prefix_matching) { true }
+      it 'contains pattern without "$" at the end' do
+        is_expected.to include('pattern' => '/v1/some/path')
       end
     end
   end

--- a/spec/unit/commands/import_command/openapi/threescale_api_spec_spec.rb
+++ b/spec/unit/commands/import_command/openapi/threescale_api_spec_spec.rb
@@ -61,16 +61,35 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::ThreeScaleAp
     expect(subject.description).to eq(description)
   end
 
-  it 'operations available' do
-    expect(subject.operations).not_to be_nil
-  end
+  context '#operations' do
+    it 'operations available' do
+      expect(subject.operations).not_to be_nil
+    end
 
-  it 'operations parsed as not empty' do
-    expect(subject.operations).not_to be_empty
-  end
+    it 'operations parsed as not empty' do
+      expect(subject.operations).not_to be_empty
+    end
 
-  it 'operations parsed type' do
-    expect(subject.operations[0]).to be_a(ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::Operation)
+    it 'operations parsed type' do
+      expect(subject.operations[0]).to be_a(ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::Operation)
+    end
+
+    it 'operations have strict matching set by default' do
+      subject.operations.each do |operation|
+        expect(operation.operation).to include(:prefix_matching => false)
+      end
+    end
+
+    context 'with ThreeScaleSpec with prefix matching set' do
+      let(:prefix_matching) { true }
+      subject { described_class.new(openapi, base_path, prefix_matching) }
+
+      it 'returns operations with prefix matching parameter' do
+        subject.operations.each do |operation|
+          expect(operation.operation).to include(:prefix_matching => prefix_matching)
+        end
+      end
+    end
   end
 
   context '#schemes' do


### PR DESCRIPTION
Add --prefix-matching in import openapi command.
Pending tests. Tests will be added in this PR once the implemented approach is deemed correct.