### PR TITLE
Do not set skip_swagger_validation when not provided as an option in activedocs apply

### DIFF
--- a/docs/activedocs.md
+++ b/docs/activedocs.md
@@ -94,8 +94,8 @@ OPTIONS
                                        on the Developer Portal. Otherwise it
                                        will be hidden
     -s --name=<value>                  Specify the name of the ActiveDocs
-       --skip-swagger-validations      Specify it to skip validation of the
-                                       Swagger specification
+       --skip-swagger-validations      Skip validation of the Swagger
+                                       specification. true or false
 
 OPTIONS FOR ACTIVEDOCS
     -c --config-file=<value>           3scale toolbox configuration file

--- a/lib/3scale_toolbox/commands/activedocs_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/activedocs_command/apply_command.rb
@@ -20,7 +20,7 @@ module ThreeScaleToolbox
               option :i, :'service-id', "Specify the Service ID associated to the ActiveDocs", argument: :required
               option :p, :'publish', "Specify it to publish the ActiveDocs on the Developer Portal. Otherwise it will be hidden", argument: :forbidden
               option nil, :'hide', "Specify it to hide the ActiveDocs on the Developer Portal", argument: :forbidden
-              option nil, :'skip-swagger-validations', "Specify it to skip validation of the Swagger specification", argument: :forbidden
+              option nil, :'skip-swagger-validations', "Skip validation of the Swagger specification. true or false", argument: :required, transform: ThreeScaleToolbox::Helper::BooleanTransformer.new
               option :d, :'description', "Specify the description of the ActiveDocs", argument: :required
               option :s, :'name', "Specify the name of the ActiveDocs", argument: :required
               option nil, :'openapi-spec', "Specify the swagger spec. Can be a file, an URL or '-' to read from stdin. This option is mandatory when applying the ActiveDoc for the first time", argument: :required

--- a/spec/integration/commands/activedocs_command/apply_command_spec.rb
+++ b/spec/integration/commands/activedocs_command/apply_command_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'ActiveDocs Apply command' do
     let (:command_line_str) { "activedocs apply #{remote} #{activedocs_ref} #{options}" }
     before :example do
       ThreeScaleToolbox::Entities::ActiveDocs::create(remote: api3scale_client,
-                                                      attrs: { "name" => activedocs_ref, "body" => activedocs_body_pretty_json, "published" => true, "description" => "olddescription" })
+                                                      attrs: { "name" => activedocs_ref, "body" => activedocs_body_pretty_json, "published" => true, "description" => "olddescription", "skip_swagger_validations" => true })
     end
 
     it "is updated" do
@@ -70,6 +70,7 @@ RSpec.describe 'ActiveDocs Apply command' do
       expect(res.attrs.fetch("body")).to eq(activedocs_body_pretty_json)
       expect(res.attrs.fetch("published")).to eq(false)
       expect(res.attrs.fetch("description")).to eq("newdescription")
+      expect(res.attrs.fetch("skip_swagger_validations")).to eq(true)
     end
 
     after :example do


### PR DESCRIPTION
Make activedocs apply command not set skip_swagger_validations on activedocs update.
Notice that this breaks compatibility with possible existing scripts so we should document in the new release that the scripts should be updated. It also changes default behavior, although it is a fix to a behavior that it should not exist.