### PR TITLE
Structured output: 

### DIFF
--- a/docs/activedocs.md
+++ b/docs/activedocs.md
@@ -34,6 +34,7 @@ OPTIONS
                                        ActiveDocs
     -i --service-id=<value>            Specify the Service ID associated to
                                        the ActiveDocs
+    -o --output=<value>                Output format. One of: json|yaml
     -p --published                     Specify it to publish the ActiveDoc on
                                        the Developer Portal. Otherwise it
                                        will be hidden
@@ -79,23 +80,28 @@ DESCRIPTION
     Create or update an ActiveDocs
 
 OPTIONS
-    -d --description=<value>           Specify the description of the
-                                       ActiveDocs
-       --hide                          Specify it to hide the ActiveDocs on
-                                       the Developer Portal
-    -i --service-id=<value>            Specify the Service ID associated to
-                                       the ActiveDocs
-       --openapi-spec=<value>          Specify the swagger spec. Can be a
-                                       file, an URL or '-' to read from
-                                       stdin. This option is mandatory when
-                                       applying the ActiveDoc for the first
-                                       time
-    -p --publish                       Specify it to publish the ActiveDocs
-                                       on the Developer Portal. Otherwise it
-                                       will be hidden
-    -s --name=<value>                  Specify the name of the ActiveDocs
-       --skip-swagger-validations      Skip validation of the Swagger
-                                       specification. true or false
+    -d --description=<value>                   Specify the description of the
+                                               ActiveDocs
+       --hide                                  Specify it to hide the
+                                               ActiveDocs on the Developer
+                                               Portal
+    -i --service-id=<value>                    Specify the Service ID
+                                               associated to the ActiveDocs
+    -o --output=<value>                        Output format. One of:
+                                               json|yaml
+       --openapi-spec=<value>                  Specify the swagger spec. Can
+                                               be a file, an URL or '-' to
+                                               read from stdin. This option
+                                               is mandatory when applying the
+                                               ActiveDoc for the first time
+    -p --publish                               Specify it to publish the
+                                               ActiveDocs on the Developer
+                                               Portal. Otherwise it will be
+                                               hidden
+    -s --name=<value>                          Specify the name of the
+                                               ActiveDocs
+       --skip-swagger-validations=<value>      Skip validation of the Swagger
+                                               specification. true or false
 
 OPTIONS FOR ACTIVEDOCS
     -c --config-file=<value>           3scale toolbox configuration file
@@ -122,6 +128,7 @@ DESCRIPTION
     List all defined ActiveDocs
 
 OPTIONS
+    -o --output=<value>           Output format. One of: json|yaml
     -s --service-ref=<value>      Filter the ActiveDocs by Service reference
 
 OPTIONS FOR ACTIVEDOCS

--- a/docs/app-plan.md
+++ b/docs/app-plan.md
@@ -32,10 +32,11 @@ OPTIONS
        --approval-required=<value>      Applications require approval. true
                                         or false
        --cost-per-month=<value>         Cost per month
-    -d --default                        Make default application plan
+       --default                        Make default application plan
        --disabled                       Disables all methods and metrics in
                                         this application plan
-    -p --published                      Publish application plan
+    -o --output=<value>                 Output format. One of: json|yaml
+    -p --publish                        Publish application plan
        --setup-fee=<value>              Setup fee
     -t --system-name=<value>            Application plan system name
        --trial-period-days=<value>      Trial period days
@@ -86,6 +87,7 @@ OPTIONS
        --enabled                        Enable application plan
        --hide                           Hide application plan
     -n --name=<value>                   Plan name
+    -o --output=<value>                 Output format. One of: json|yaml
     -p --publish                        Publish application plan
        --setup-fee=<value>              Setup fee
        --trial-period-days=<value>      Trial period days
@@ -114,6 +116,9 @@ USAGE
 
 DESCRIPTION
     List application plans
+
+OPTIONS
+    -o --output=<value>           Output format. One of: json|yaml
 
 OPTIONS FOR APPLICATION-PLAN
     -c --config-file=<value>      3scale toolbox configuration file (default:
@@ -161,6 +166,9 @@ USAGE
 
 DESCRIPTION
     show application plan
+
+OPTIONS
+    -o --output=<value>           Output format. One of: json|yaml
 
 OPTIONS FOR APPLICATION-PLAN
     -c --config-file=<value>      3scale toolbox configuration file (default:

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -20,9 +20,19 @@ DESCRIPTION
 
 OPTIONS
        --account=<value>          Filter by account
+    -o --output=<value>           Output format. One of: json|yaml
        --plan=<value>             Filter by application plan. Service option
                                   required
        --service=<value>          Filter by service
+
+OPTIONS FOR APPLICATION
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
 ```
 
 ### Create
@@ -32,7 +42,7 @@ OPTIONS
   * `<service>` reference. It can be either service `id`, or service `system_name`. Toolbox will figure it out.
   * `<account>` reference. It can be one of the following and the toolbox will figure it out:
     * Account `id`
-    * `username`, `email` or `user_id` of the admin user of the account 
+    * `username`, `email` or `user_id` of the admin user of the account
     * `provider_key`
   * `<application plan>` reference. It can be either plan `id`, or plan `system_name`. Toolbox will figure it out.
   * `<name>` application name.
@@ -58,9 +68,19 @@ OPTIONS
                                       modes) of the application to be
                                       created.
        --description=<value>          Application description
+    -o --output=<value>               Output format. One of: json|yaml
        --redirect-url=<value>         OpenID Connect redirect url
        --user-key=<value>             User Key (API Key) of the application
                                       to be created.
+
+OPTIONS FOR APPLICATION
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
 ```
 
 ### Show
@@ -84,6 +104,18 @@ DESCRIPTION
     Connect authentication modes)
 
     * Application internal id
+
+OPTIONS
+    -o --output=<value>           Output format. One of: json|yaml
+
+OPTIONS FOR APPLICATION
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
 ```
 
 ### Apply
@@ -95,7 +127,7 @@ DESCRIPTION
   * Application internal id
 * `account` optional argument is required when application is not found and needs to be created. It can be one of the following and the toolbox will figure it out:
   * Account `id`
-  * `username`, `email` or `user_id` of the admin user of the account 
+  * `username`, `email` or `user_id` of the admin user of the account
   * `provider_key`
 * `name` cannot be used as unique identifier because application name is not unique in 3scale.
 * This is command is `idempotent`.
@@ -133,6 +165,7 @@ OPTIONS
                                       does not exist.
        --description=<value>          Application description
        --name=<value>                 Application name
+    -o --output=<value>               Output format. One of: json|yaml
        --plan=<value>                 Application's plan. Required when
                                       creating
        --redirect-url=<value>         OpenID Connect redirect url
@@ -143,6 +176,15 @@ OPTIONS
                                       state to suspended)
        --user-key=<value>             User Key (API Key) of the application
                                       to be created.
+
+OPTIONS FOR APPLICATION
+    -c --config-file=<value>      3scale toolbox configuration file (default:
+                                  $HOME/.3scalerc.yaml)
+    -h --help                     show help for this command
+    -k --insecure                 Proceed and operate even for server
+                                  connections otherwise considered insecure
+    -v --version                  Prints the version of this command
+       --verbose                  Verbose mode
 ```
 
 ### Delete

--- a/docs/method.md
+++ b/docs/method.md
@@ -29,6 +29,7 @@ OPTIONS
        --description=<value>      Method description
        --disabled                 Disables this method in all application
                                   plans
+    -o --output=<value>           Output format. One of: json|yaml
     -t --system-name=<value>      Method system name
 
 OPTIONS FOR METHOD
@@ -69,6 +70,7 @@ OPTIONS
        --enabled                  Enables this method in all application
                                   plans
     -n --name=<value>             Method name
+    -o --output=<value>           Output format. One of: json|yam
 
 OPTIONS FOR METHOD
     -c --config-file=<value>      3scale toolbox configuration file (default:
@@ -91,6 +93,9 @@ USAGE
 
 DESCRIPTION
     List methods
+
+OPTIONS
+    -o --output=<value>           Output format. One of: json|yaml
 
 OPTIONS FOR METHOD
     -c --config-file=<value>      3scale toolbox configuration file (default:

--- a/docs/metric.md
+++ b/docs/metric.md
@@ -29,7 +29,8 @@ OPTIONS
        --description=<value>      Metric description
        --disabled                 Disables this metric in all application
                                   plans
-    -t --system-name=<value>      Application plan system name
+    -o --output=<value>           Output format. One of: json|yaml
+    -t --system-name=<value>      Metric system name
        --unit=<value>             Metric unit. Default hit
 
 OPTIONS FOR METRIC
@@ -70,6 +71,7 @@ OPTIONS
        --enabled                  Enables this metric in all application
                                   plans
     -n --name=<value>             Metric name
+    -o --output=<value>           Output format. One of: json|yaml
        --unit=<value>             Metric unit. Default hit
 
 OPTIONS FOR METRIC
@@ -93,6 +95,9 @@ USAGE
 
 DESCRIPTION
     List metrics
+
+OPTIONS
+    -o --output=<value>           Output format. One of: json|yaml
 
 OPTIONS FOR METRIC
     -c --config-file=<value>      3scale toolbox configuration file (default:

--- a/docs/proxy-config.md
+++ b/docs/proxy-config.md
@@ -17,9 +17,12 @@ USAGE
 DESCRIPTION
     List all defined Proxy Configurations
 
+OPTIONS
+    -o --output=<value>           Output format. One of: json|yaml
+
 OPTIONS FOR PROXY-CONFIG
     -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  /home/msoriano/.3scalerc.yaml)
+                                  $HOME/.3scalerc.yaml)
     -h --help                     show help for this command
     -k --insecure                 Proceed and operate even for server
                                   connections otherwise considered insecure
@@ -43,11 +46,12 @@ DESCRIPTION
 OPTIONS
        --config-version=<value>      Specify the Proxy Configuration version.
                                      If not specified it gets the latest
-                                     version
+                                     version (default: latest)
+    -o --output=<value>              Output format. One of: json|yaml
 
 OPTIONS FOR PROXY-CONFIG
     -c --config-file=<value>         3scale toolbox configuration file
-                                     (default: /home/msoriano/.3scalerc.yaml)
+                                     (default: $HOME/.3scalerc.yaml)
     -h --help                        show help for this command
     -k --insecure                    Proceed and operate even for server
                                      connections otherwise considered
@@ -70,7 +74,7 @@ DESCRIPTION
 
 OPTIONS FOR PROXY-CONFIG
     -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  /home/msoriano/.3scalerc.yaml)
+                                  $HOME/.3scalerc.yaml)
     -h --help                     show help for this command
     -k --insecure                 Proceed and operate even for server
                                   connections otherwise considered insecure

--- a/docs/service.md
+++ b/docs/service.md
@@ -33,6 +33,7 @@ OPTIONS
                                           service
        --description=<value>              Specify the description of the
                                           service
+    -o --output=<value>                   Output format. One of: json|yaml
     -s --system-name=<value>              Specify the system-name of the
                                           service
        --support-email=<value>            Specify the support email of the
@@ -78,6 +79,7 @@ OPTIONS
        --description=<value>              Specify the description of the
                                           service
     -n --name=<value>                     Specify the name of the metric
+    -o --output=<value>                   Output format. One of: json|yaml
        --support-email=<value>            Specify the support email of the
                                           service
 
@@ -105,6 +107,9 @@ USAGE
 DESCRIPTION
     List all services
 
+OPTIONS
+    -o --output=<value>           Output format. One of: json|yaml
+
 OPTIONS FOR SERVICE
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
@@ -126,6 +131,9 @@ USAGE
 
 DESCRIPTION
     Show the information of a service
+
+OPTIONS
+    -o --output=<value>           Output format. One of: json|yaml
 
 OPTIONS FOR SERVICE
     -c --config-file=<value>      3scale toolbox configuration file (default:

--- a/lib/3scale_toolbox/cli.rb
+++ b/lib/3scale_toolbox/cli.rb
@@ -1,4 +1,7 @@
 require '3scale_toolbox/cli/error_handler'
+require '3scale_toolbox/cli/json_printer'
+require '3scale_toolbox/cli/yaml_printer'
+require '3scale_toolbox/cli/output_flag'
 
 module ThreeScaleToolbox::CLI
   def self.root_command

--- a/lib/3scale_toolbox/cli.rb
+++ b/lib/3scale_toolbox/cli.rb
@@ -1,6 +1,7 @@
 require '3scale_toolbox/cli/error_handler'
 require '3scale_toolbox/cli/json_printer'
 require '3scale_toolbox/cli/yaml_printer'
+require '3scale_toolbox/cli/custom_table_printer'
 require '3scale_toolbox/cli/output_flag'
 
 module ThreeScaleToolbox::CLI

--- a/lib/3scale_toolbox/cli/custom_table_printer.rb
+++ b/lib/3scale_toolbox/cli/custom_table_printer.rb
@@ -1,0 +1,32 @@
+module ThreeScaleToolbox
+  module CLI
+    class CustomTablePrinter
+      attr_reader :fields
+
+      def initialize(fields)
+        @fields = fields
+      end
+
+      def print_record(record)
+        print_collection([record])
+      end
+
+      def print_collection(collection)
+        print_header
+        print_data(collection)
+      end
+
+      private
+
+      def print_header
+        puts fields.map(&:upcase).join("\t")
+      end
+
+      def print_data(collection)
+        collection.each do |obj|
+          puts fields.map { |field| obj.fetch(field, '(empty)').to_s }.join("\t")
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/cli/json_printer.rb
+++ b/lib/3scale_toolbox/cli/json_printer.rb
@@ -1,0 +1,13 @@
+module ThreeScaleToolbox
+  module CLI
+    class JsonPrinter
+      def print_record(record)
+        puts JSON.pretty_generate(record)
+      end
+
+      def print_collection(collection)
+        puts JSON.pretty_generate(collection)
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/cli/output_flag.rb
+++ b/lib/3scale_toolbox/cli/output_flag.rb
@@ -1,0 +1,20 @@
+module ThreeScaleToolbox
+  module CLI
+    class PrinterTransformer
+      def call(output_format)
+        raise unless %w[yaml json].include?(output_format)
+
+        case output_format
+        when 'yaml'
+          YamlPrinter.new
+        when 'json'
+          JsonPrinter.new
+        end
+      end
+    end
+
+    def self.output_flag(dsl)
+      dsl.option :o, :output, 'Output format. One of: json|yaml', argument: :required, transform: PrinterTransformer.new
+    end
+  end
+end

--- a/lib/3scale_toolbox/cli/yaml_printer.rb
+++ b/lib/3scale_toolbox/cli/yaml_printer.rb
@@ -1,0 +1,13 @@
+module ThreeScaleToolbox
+  module CLI
+    class YamlPrinter
+      def print_record(record)
+        puts YAML.dump(record)
+      end
+
+      def print_collection(collection)
+        puts YAML.dump(collection)
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/activedocs_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/activedocs_command/apply_command.rb
@@ -140,14 +140,8 @@ module ThreeScaleToolbox
           end
 
           def printer
-            if options.key?(:output)
-              options.fetch(:output)
-            else
-              # keep backwards compatibility
-              CustomPrinter.new(
-                publish: option_publish, hide: option_hide
-              )
-            end
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new(publish: option_publish, hide: option_hide))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/activedocs_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/activedocs_command/create_command.rb
@@ -70,12 +70,8 @@ module ThreeScaleToolbox
           end
 
           def printer
-            if options.key?(:output)
-              options.fetch(:output)
-            else
-              # keep backwards compatibility
-              CustomPrinter.new
-            end
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new)
           end
         end
       end

--- a/lib/3scale_toolbox/commands/application_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/apply_command.rb
@@ -206,12 +206,8 @@ module ThreeScaleToolbox
           end
 
           def printer
-            if options.key?(:output)
-              options.fetch(:output)
-            else
-              # keep backwards compatibility
-              CustomPrinter.new(resume: option_resume, suspend: option_suspend)
-            end
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new(resume: option_resume, suspend: option_suspend))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/application_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/apply_command.rb
@@ -2,6 +2,24 @@ module ThreeScaleToolbox
   module Commands
     module ApplicationCommand
       module Apply
+        class CustomPrinter
+          attr_reader :option_resume, :option_suspend
+
+          def initialize(options)
+            @option_resume = options[:resume]
+            @option_suspend = options[:suspend]
+          end
+
+          def print_record(application)
+            output_msg_array = ["Applied application id: #{application['id']}"]
+            output_msg_array << 'Resumed' if option_resume
+            output_msg_array << 'Suspended' if option_suspend
+            puts output_msg_array.join('; ')
+          end
+
+          def print_collection(collection) end
+        end
+
         class ApplySubcommand < Cri::CommandRunner
           include ThreeScaleToolbox::Command
 
@@ -28,6 +46,8 @@ module ThreeScaleToolbox
               option      nil, :'redirect-url', 'OpenID Connect redirect url', argument: :required
               flag        nil, :resume, 'Resume a suspended application'
               flag        nil, :suspend, 'Suspends an application (changes the state to suspended)'
+              ThreeScaleToolbox::CLI.output_flag(self)
+
               param       :remote
               param       :application
 
@@ -52,10 +72,8 @@ module ThreeScaleToolbox
 
             application.resume if option_resume
             application.suspend if option_suspend
-            output_msg_array = ["Applied application id: #{application.id}"]
-            output_msg_array << 'Resumed' if option_resume
-            output_msg_array << 'Suspended' if option_suspend
-            puts output_msg_array.join('; ')
+
+            printer.print_record application.attrs
           end
 
           private
@@ -185,6 +203,15 @@ module ThreeScaleToolbox
 
           def option_redirect_url
             options[:'redirect-url']
+          end
+
+          def printer
+            if options.key?(:output)
+              options.fetch(:output)
+            else
+              # keep backwards compatibility
+              CustomPrinter.new(resume: option_resume, suspend: option_suspend)
+            end
           end
         end
       end

--- a/lib/3scale_toolbox/commands/application_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/create_command.rb
@@ -117,12 +117,8 @@ module ThreeScaleToolbox
           end
 
           def printer
-            if options.key?(:output)
-              options.fetch(:output)
-            else
-              # keep backwards compatibility
-              CustomPrinter.new
-            end
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new)
           end
         end
       end

--- a/lib/3scale_toolbox/commands/application_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/create_command.rb
@@ -2,6 +2,14 @@ module ThreeScaleToolbox
   module Commands
     module ApplicationCommand
       module Create
+        class CustomPrinter
+          def print_record(application)
+            puts "Created application id: #{application['id']}"
+          end
+
+          def print_collection(collection) end
+        end
+
         class CreateSubcommand < Cri::CommandRunner
           include ThreeScaleToolbox::Command
 
@@ -17,6 +25,8 @@ module ThreeScaleToolbox
               option      nil, 'application-key', 'App Key(s) or Client Secret (for OAuth and OpenID Connect authentication modes) of the application to be created.' , argument: :required
               option      nil, :description, 'Application description', argument: :required
               option      nil, :'redirect-url', 'OpenID Connect redirect url', argument: :required
+              ThreeScaleToolbox::CLI.output_flag(self)
+
               param       :remote
               param       :account
               param       :service
@@ -35,7 +45,7 @@ module ThreeScaleToolbox
               app_attrs: app_attrs
             )
 
-            puts "Created application id: #{application.id}"
+            printer.print_record application.attrs
           end
 
           private
@@ -104,6 +114,15 @@ module ThreeScaleToolbox
 
           def remote
             @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def printer
+            if options.key?(:output)
+              options.fetch(:output)
+            else
+              # keep backwards compatibility
+              CustomPrinter.new
+            end
           end
         end
       end

--- a/lib/3scale_toolbox/commands/application_command/list_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/list_command.rb
@@ -14,10 +14,12 @@ module ThreeScaleToolbox
               summary     'list applications'
               description 'List applications'
 
-              param       :remote
               option      nil, :account, 'Filter by account', argument: :required
               option      nil, :service, 'Filter by service', argument: :required
               option      nil, :plan, 'Filter by application plan. Service option required', argument: :required
+              ThreeScaleToolbox::CLI.output_flag(self)
+
+              param       :remote
 
               runner ListSubcommand
             end
@@ -35,8 +37,8 @@ module ThreeScaleToolbox
                            else
                              provider_account_applications
                            end
-            print_header
-            print_data(applications)
+
+            printer.print_collection applications.map(&:attrs)
           end
 
           private
@@ -70,16 +72,6 @@ module ThreeScaleToolbox
 
           def option_plan
             options[:plan]
-          end
-
-          def print_header
-            puts FIELDS_TO_SHOW.map(&:upcase).join("\t")
-          end
-
-          def print_data(applications)
-            applications.each do |app|
-              puts FIELDS_TO_SHOW.map { |field| app.attrs.fetch(field, '(empty)') }.join("\t")
-            end
           end
 
           def service
@@ -116,6 +108,11 @@ module ThreeScaleToolbox
 
           def remote
             @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def printer
+            # keep backwards compatibility
+            options.fetch(:output, CLI::CustomTablePrinter.new(FIELDS_TO_SHOW))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/application_command/show_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/show_command.rb
@@ -21,6 +21,8 @@ module ThreeScaleToolbox
               \n * Application internal id
               HEREDOC
 
+              ThreeScaleToolbox::CLI.output_flag(self)
+
               param       :remote
               param       :application
 
@@ -29,23 +31,10 @@ module ThreeScaleToolbox
           end
 
           def run
-            print_header
-            print_data
+            printer.print_record application.attrs
           end
 
           private
-
-          def print_header
-            puts FIELDS_TO_SHOW.map(&:upcase).join("\t")
-          end
-
-          def print_data
-            puts FIELDS_TO_SHOW.map { |field| app_attrs.fetch(field, '(empty)') }.join("\t")
-          end
-
-          def app_attrs
-            @app_attrs ||= application.attrs
-          end
 
           def application
             @application ||= find_application
@@ -63,6 +52,11 @@ module ThreeScaleToolbox
 
           def remote
             @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def printer
+            # keep backwards compatibility
+            options.fetch(:output, CLI::CustomTablePrinter.new(FIELDS_TO_SHOW))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/methods_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command/apply_command.rb
@@ -113,12 +113,8 @@ module ThreeScaleToolbox
           end
 
           def printer
-            if options.key?(:output)
-              options.fetch(:output)
-            else
-              # keep backwards compatibility
-              CustomPrinter.new(disabled: option_disabled, enabled: option_enabled)
-            end
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new(disabled: option_disabled, enabled: option_enabled))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/methods_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command/create_command.rb
@@ -2,6 +2,20 @@ module ThreeScaleToolbox
   module Commands
     module MethodsCommand
       module Create
+        class CustomPrinter
+          attr_reader :option_disabled
+
+          def initialize(options)
+            @option_disabled = options[:disabled]
+          end
+
+          def print_record(method)
+            puts "Created method id: #{method['id']}. Disabled: #{option_disabled}"
+          end
+
+          def print_collection(collection) end
+        end
+
         class CreateSubcommand < Cri::CommandRunner
           include ThreeScaleToolbox::Command
 
@@ -15,6 +29,8 @@ module ThreeScaleToolbox
               option      :t, 'system-name', 'Method system name', argument: :required
               flag        nil, :disabled, 'Disables this method in all application plans'
               option      nil, :description, 'Method description', argument: :required
+              ThreeScaleToolbox::CLI.output_flag(self)
+
               param       :remote
               param       :service_ref
               param       :method_name
@@ -31,7 +47,8 @@ module ThreeScaleToolbox
               attrs: method_attrs
             )
             method.disable if option_disabled
-            puts "Created method id: #{method.id}. Disabled: #{option_disabled}"
+
+            printer.print_record method.attrs
           end
 
           private
@@ -65,6 +82,15 @@ module ThreeScaleToolbox
 
           def service_ref
             arguments[:service_ref]
+          end
+
+          def printer
+            if options.key?(:output)
+              options.fetch(:output)
+            else
+              # keep backwards compatibility
+              CustomPrinter.new(disabled: option_disabled)
+            end
           end
         end
       end

--- a/lib/3scale_toolbox/commands/methods_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command/create_command.rb
@@ -85,12 +85,8 @@ module ThreeScaleToolbox
           end
 
           def printer
-            if options.key?(:output)
-              options.fetch(:output)
-            else
-              # keep backwards compatibility
-              CustomPrinter.new(disabled: option_disabled)
-            end
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new(disabled: option_disabled))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/methods_command/list_command.rb
+++ b/lib/3scale_toolbox/commands/methods_command/list_command.rb
@@ -14,6 +14,7 @@ module ThreeScaleToolbox
               summary     'list methods'
               description 'List methods'
 
+              ThreeScaleToolbox::CLI.output_flag(self)
               param       :remote
               param       :service_ref
 
@@ -22,21 +23,17 @@ module ThreeScaleToolbox
           end
 
           def run
-            print_header
-            print_data
+            printer.print_collection service_methods
           end
 
           private
 
-          def print_header
-            puts FIELDS_TO_SHOW.map(&:upcase).join("\t")
+          def service_methods
+            @service_methods ||= service.methods service_hits_id
           end
 
-          def print_data
-            hits = service.hits
-            service.methods(hits.fetch('id')).each do |method|
-              puts FIELDS_TO_SHOW.map { |field| method.fetch(field, '(empty)') }.join("\t")
-            end
+          def service_hits_id
+            @service_hits_id ||= service.hits.fetch('id')
           end
 
           def service
@@ -56,6 +53,11 @@ module ThreeScaleToolbox
 
           def service_ref
             arguments[:service_ref]
+          end
+
+          def printer
+            # keep backwards compatibility
+            options.fetch(:output, CLI::CustomTablePrinter.new(FIELDS_TO_SHOW))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/metrics_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command/apply_command.rb
@@ -114,12 +114,8 @@ module ThreeScaleToolbox
           end
 
           def printer
-            if options.key?(:output)
-              options.fetch(:output)
-            else
-              # keep backwards compatibility
-              CustomPrinter.new(disabled: option_disabled, enabled: option_enabled)
-            end
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new(disabled: option_disabled, enabled: option_enabled))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/metrics_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command/create_command.rb
@@ -89,12 +89,8 @@ module ThreeScaleToolbox
           end
 
           def printer
-            if options.key?(:output)
-              options.fetch(:output)
-            else
-              # keep backwards compatibility
-              CustomPrinter.new(disabled: option_disabled)
-            end
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new(disabled: option_disabled))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/metrics_command/list_command.rb
+++ b/lib/3scale_toolbox/commands/metrics_command/list_command.rb
@@ -14,6 +14,7 @@ module ThreeScaleToolbox
               summary     'list metrics'
               description 'List metrics'
 
+              ThreeScaleToolbox::CLI.output_flag(self)
               param       :remote
               param       :service_ref
 
@@ -22,21 +23,10 @@ module ThreeScaleToolbox
           end
 
           def run
-            print_header
-            print_data
+            printer.print_collection service.metrics
           end
 
           private
-
-          def print_header
-            puts FIELDS_TO_SHOW.map(&:upcase).join("\t")
-          end
-
-          def print_data
-            service.metrics.each do |metric|
-              puts FIELDS_TO_SHOW.map { |field| metric.fetch(field, '(empty)') }.join("\t")
-            end
-          end
 
           def service
             @service ||= find_service
@@ -55,6 +45,11 @@ module ThreeScaleToolbox
 
           def service_ref
             arguments[:service_ref]
+          end
+
+          def printer
+            # keep backwards compatibility
+            options.fetch(:output, CLI::CustomTablePrinter.new(FIELDS_TO_SHOW))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/plans_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/plans_command/create_command.rb
@@ -2,6 +2,21 @@ module ThreeScaleToolbox
   module Commands
     module PlansCommand
       module Create
+        class CustomPrinter
+          attr_reader :option_default, :option_disabled
+
+          def initialize(option_default, option_disabled)
+            @option_default = option_default
+            @option_disabled = option_disabled
+          end
+
+          def print_record(plan)
+            puts "Created application plan id: #{plan['id']}. Default: #{option_default}; Disabled: #{option_disabled}"
+          end
+
+          def print_collection(collection) end
+        end
+
         class CreateSubcommand < Cri::CommandRunner
           include ThreeScaleToolbox::Command
 
@@ -20,6 +35,8 @@ module ThreeScaleToolbox
               option      nil, 'cost-per-month', 'Cost per month', argument: :required, transform: method(:Float)
               option      nil, 'setup-fee', 'Setup fee', argument: :required, transform: method(:Float)
               option      nil, 'trial-period-days', 'Trial period days', argument: :required, transform: method(:Integer)
+              ThreeScaleToolbox::CLI.output_flag(self)
+
               param       :remote
               param       :service_ref
               param       :plan_name
@@ -32,7 +49,7 @@ module ThreeScaleToolbox
             plan = create_application_plan
             plan.make_default if option_default
             plan.disable if option_disabled
-            puts "Created application plan id: #{plan.id}. Default: #{option_default}; Disabled: #{option_disabled}"
+            printer.print_record plan.attrs
           end
 
           private
@@ -90,6 +107,11 @@ module ThreeScaleToolbox
 
           def service_ref
             arguments[:service_ref]
+          end
+
+          def printer
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new(option_default, option_disabled))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/plans_command/list_command.rb
+++ b/lib/3scale_toolbox/commands/plans_command/list_command.rb
@@ -5,7 +5,7 @@ module ThreeScaleToolbox
         class ListSubcommand < Cri::CommandRunner
           include ThreeScaleToolbox::Command
 
-          FIELDS_TO_SHOW = %w[id name system_name].freeze
+          FIELDS = %w[id name system_name].freeze
 
           def self.command
             Cri::Command.define do
@@ -14,6 +14,7 @@ module ThreeScaleToolbox
               summary     'list application plans'
               description 'List application plans'
 
+              ThreeScaleToolbox::CLI.output_flag(self)
               param       :remote
               param       :service_ref
 
@@ -22,21 +23,10 @@ module ThreeScaleToolbox
           end
 
           def run
-            print_header
-            print_data
+            printer.print_collection service.plans
           end
 
           private
-
-          def print_header
-            puts FIELDS_TO_SHOW.map(&:upcase).join("\t")
-          end
-
-          def print_data
-            service.plans.each do |plan|
-              puts FIELDS_TO_SHOW.map { |field| plan.fetch(field, '(empty)') }.join("\t")
-            end
-          end
 
           def service
             @service ||= find_service
@@ -55,6 +45,11 @@ module ThreeScaleToolbox
 
           def service_ref
             arguments[:service_ref]
+          end
+
+          def printer
+            # keep backwards compatibility
+            options.fetch(:output, CLI::CustomTablePrinter.new(FIELDS))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/plans_command/show_command.rb
+++ b/lib/3scale_toolbox/commands/plans_command/show_command.rb
@@ -15,6 +15,7 @@ module ThreeScaleToolbox
               summary     'show application plan'
               description 'show application plan'
 
+              ThreeScaleToolbox::CLI.output_flag(self)
               param       :remote
               param       :service_ref
               param       :plan_ref
@@ -24,26 +25,13 @@ module ThreeScaleToolbox
           end
 
           def run
-            print_header
-            print_data
+            printer.print_record plan.attrs
           end
 
           private
 
-          def print_header
-            puts FIELDS_TO_SHOW.map(&:upcase).join("\t")
-          end
-
-          def print_data
-            puts FIELDS_TO_SHOW.map { |field| plan_attrs.fetch(field, '(empty)') }.join("\t")
-          end
-
           def service
             @service ||= find_service
-          end
-
-          def plan_attrs
-            @plan_attrs ||= plan.attrs
           end
 
           def plan
@@ -73,6 +61,10 @@ module ThreeScaleToolbox
 
           def plan_ref
             arguments[:plan_ref]
+          end
+
+          def printer
+            options.fetch(:output, CLI::CustomTablePrinter.new(FIELDS_TO_SHOW))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/proxy_config_command/list_command.rb
+++ b/lib/3scale_toolbox/commands/proxy_config_command/list_command.rb
@@ -5,29 +5,29 @@ module ThreeScaleToolbox
         class ListSubcommand < Cri::CommandRunner
           include ThreeScaleToolbox::Command
 
+          FIELDS = %w[id version environment]
+
           def self.command
             Cri::Command.define do
               name        'list'
               usage       'list <remote> <service> <environment>'
               summary     'List Proxy Configurations'
               description 'List all defined Proxy Configurations'
-              runner ListSubcommand
 
+              ThreeScaleToolbox::CLI.output_flag(self)
               param   :remote
               param   :service_ref
               param   :environment
+
+              runner ListSubcommand
             end
           end
 
           def run
-            print_proxy_config_data(proxy_configs, PROXYCONFIG_FIELDS_TO_SHOW)
+            printer.print_collection service.proxy_configs(proxy_config_environment).map(&:attrs)
           end
 
           private
-
-          PROXYCONFIG_FIELDS_TO_SHOW = %w[
-            id version environment
-          ]
 
           def remote
             @remote ||= threescale_client(arguments[:remote])
@@ -41,35 +41,19 @@ module ThreeScaleToolbox
             arguments[:service_ref]
           end
 
-          def proxy_configs
-            @proxyconfigs ||= service.proxy_configs(proxy_config_environment)
-          end
-
-          def print_proxy_config_data(proxyconfigs, fields_to_show)
-            print_header(fields_to_show)
-            print_results(proxyconfigs, fields_to_show)
-          end
-
-          def print_header(fields_to_show)
-            puts fields_to_show.map{ |e| e.upcase}.join("\t")
-          end
-
-          def print_results(proxyconfigs, fields_to_show)
-            proxyconfigs.each do |proxyconfig|
-              proxy_config_attrs = proxyconfig.attrs
-              puts fields_to_show.map { |field| proxy_config_attrs.fetch(field, '(empty)') }.join("\t")
-            end
-          end
-
           def find_service
-            Entities::Service.find(remote: remote,
-                                   ref: service_ref).tap do |svc|
+            Entities::Service.find(remote: remote, ref: service_ref).tap do |svc|
               raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
             end
           end
 
           def service
             @service ||= find_service
+          end
+
+          def printer
+            # keep backwards compatibility
+            options.fetch(:output, CLI::CustomTablePrinter.new(FIELDS))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/proxy_config_command/show_command.rb
+++ b/lib/3scale_toolbox/commands/proxy_config_command/show_command.rb
@@ -11,41 +11,39 @@ module ThreeScaleToolbox
               usage       'show <remote> <service> <environment>'
               summary     'Show Proxy Configuration'
               description 'Show a Proxy Configuration'
-              runner ShowSubcommand
 
               param   :remote
               param   :service_ref
               param   :environment
 
-              option nil, :'config-version', "Specify the Proxy Configuration version. If not specified it gets the latest version", argument: :required
+              ThreeScaleToolbox::CLI.output_flag(self)
+              option nil, :'config-version', "Specify the Proxy Configuration version. If not specified it gets the latest version", default: 'latest', argument: :required
+
+              runner ShowSubcommand
             end
           end
 
-          def run      
-            print_proxy_config
+          def run
+            printer.print_record proxy_config.attrs
           end
 
           private
 
           def proxy_config
-            @proxy_config ||= find_proxy_config 
-          end
-
-          def find_proxy_config
-            if proxy_config_version == "latest"
-              find_proxy_config_latest
+            if proxy_config_version_option == 'latest'
+              proxy_config_latest
             else
-              find_proxy_config_version
+              proxy_config_version
             end
           end
 
-          def find_proxy_config_version
-            Entities::ProxyConfig.find(service: service, environment: proxy_config_environment, version: proxy_config_version).tap do |pc|
+          def proxy_config_version
+            Entities::ProxyConfig.find(service: service, environment: proxy_config_environment, version: proxy_config_version_option).tap do |pc|
               raise ThreeScaleToolbox::Error, "ProxyConfig #{proxy_config_environment} in service #{service.id} does not exist" if pc.nil?
             end
           end
 
-          def find_proxy_config_latest
+          def proxy_config_latest
             Entities::ProxyConfig.find_latest(service: service, environment: proxy_config_environment).tap do |pc|
               raise ThreeScaleToolbox::Error, "ProxyConfig #{proxy_config_environment} in service #{service.id} does not exist" if pc.nil?
             end
@@ -55,16 +53,12 @@ module ThreeScaleToolbox
             @remote ||= threescale_client(arguments[:remote])
           end
 
-          def proxy_config_version
-            options[:'config-version'] || "latest"
+          def proxy_config_version_option
+            options[:'config-version']
           end
 
           def proxy_config_environment
             arguments[:environment]
-          end
-
-          def print_proxy_config
-            puts JSON.pretty_generate(proxy_config.attrs)    
           end
 
           def service_ref
@@ -72,14 +66,17 @@ module ThreeScaleToolbox
           end
 
           def find_service
-            Entities::Service.find(remote: remote,
-                                   ref: service_ref).tap do |svc|
+            Entities::Service.find(remote: remote, ref: service_ref).tap do |svc|
               raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
             end
           end
 
           def service
             @service ||= find_service
+          end
+
+          def printer
+            options.fetch(:output, CLI::JsonPrinter.new)
           end
         end
       end

--- a/lib/3scale_toolbox/commands/service_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/service_command/create_command.rb
@@ -2,6 +2,16 @@ module ThreeScaleToolbox
   module Commands
     module ServiceCommand
       module Create
+        class CustomPrinter
+          attr_reader :option_default, :option_disabled
+
+          def print_record(service)
+            puts "Service '#{service['name']}' has been created with ID: #{service['id']}"
+          end
+
+          def print_collection(collection) end
+        end
+
         class CreateSubcommand < Cri::CommandRunner
           include ThreeScaleToolbox::Command
 
@@ -11,23 +21,24 @@ module ThreeScaleToolbox
               usage       'create [options] <remote> <service-name>'
               summary     'Create a service'
               description 'Create a service'
-              runner CreateSubcommand
 
               param   :remote
               param   :service_name
 
+              ThreeScaleToolbox::CLI.output_flag(self)
               option :d, :'deployment-mode', "Specify the deployment mode of the service", argument: :required
               option :s, :'system-name', "Specify the system-name of the service", argument: :required
               option :a, :'authentication-mode', "Specify authentication mode of the service ('1' for API key, '2' for App Id / App Key, 'oauth' for OAuth mode, 'oidc' for OpenID Connect)", argument: :required
               option nil, :description, "Specify the description of the service", argument: :required
               option nil, :'support-email', "Specify the support email of the service", argument: :required
+
+              runner CreateSubcommand
             end
           end
 
           def run
-            create_service_params = service_attrs
-            result = Entities::Service.create(remote: remote, service_params: create_service_params)
-            puts "Service '#{arguments[:service_name]}' has been created with ID: #{result.id}"
+            service = Entities::Service.create(remote: remote, service_params: create_params)
+            printer.print_record service.attrs
           end
 
           private
@@ -46,11 +57,16 @@ module ThreeScaleToolbox
             }.compact
           end
 
-          def service_attrs
+          def create_params
             service_name = arguments[:service_name]
             create_service_attrs = parse_options
-            create_service_attrs["name"] = service_name
+            create_service_attrs['name'] = service_name
             create_service_attrs
+          end
+
+          def printer
+            # keep backwards compatibility
+            options.fetch(:output, CustomPrinter.new)
           end
         end
       end

--- a/lib/3scale_toolbox/commands/service_command/list_command.rb
+++ b/lib/3scale_toolbox/commands/service_command/list_command.rb
@@ -5,43 +5,35 @@ module ThreeScaleToolbox
         class ListSubcommand < Cri::CommandRunner
           include ThreeScaleToolbox::Command
 
+          FIELDS = %w[id name system_name]
+
           def self.command
             Cri::Command.define do
               name        'list'
               usage       'list <remote>'
               summary     'List all services'
               description 'List all services'
-              runner ListSubcommand
 
+              ThreeScaleToolbox::CLI.output_flag(self)
               param :remote
+
+              runner ListSubcommand
             end
           end
 
           def run
-            print_header
-            print_data
+            printer.print_collection remote.list_services
           end
 
           private
-
-          SERVICE_FIELDS_TO_SHOW = %w[id name system_name]
-
-          def services
-            @services ||= remote.list_services()
-          end
 
           def remote
             @remote ||= threescale_client(arguments[:remote])
           end
 
-          def print_header
-            puts SERVICE_FIELDS_TO_SHOW.map { |e| e.upcase }.join("\t")
-          end
-
-          def print_data
-            services.each do |service|
-              puts SERVICE_FIELDS_TO_SHOW.map { |field| service.fetch(field, '(empty)') }.join("\t")
-            end
+          def printer
+            # keep backwards compatibility
+            options.fetch(:output, CLI::CustomTablePrinter.new(FIELDS))
           end
         end
       end

--- a/lib/3scale_toolbox/commands/service_command/show_command.rb
+++ b/lib/3scale_toolbox/commands/service_command/show_command.rb
@@ -5,31 +5,32 @@ module ThreeScaleToolbox
         class ShowSubcommand < Cri::CommandRunner
           include ThreeScaleToolbox::Command
 
+          FIELDS = %w[
+            id name state system_name end_user_registration_required
+            backend_version deployment_option support_email description
+            created_at updated_at
+          ]
+
           def self.command
             Cri::Command.define do
               name        'show'
               usage       'show <remote> <service-id_or_system-name>'
               summary     'Show the information of a service'
               description "Show the information of a service"
-              runner ShowSubcommand
 
+              ThreeScaleToolbox::CLI.output_flag(self)
               param   :remote
               param   :service_id_or_system_name
+
+              runner ShowSubcommand
             end
           end
 
           def run
-            print_header
-            print_data
+            printer.print_record service.attrs
           end
 
           private
-
-          SERVICE_FIELDS_TO_SHOW = %w[
-            id name state system_name end_user_registration_required
-            backend_version deployment_option support_email description
-            created_at updated_at
-          ]
 
           def remote
             @remote ||= threescale_client(arguments[:remote])
@@ -49,12 +50,8 @@ module ThreeScaleToolbox
             end
           end
 
-          def print_header
-            puts SERVICE_FIELDS_TO_SHOW.map { |e| e.upcase }.join("\t")
-          end
-
-          def print_data
-            puts SERVICE_FIELDS_TO_SHOW.map { |field| service.attrs.fetch(field, '(empty)') }.join("\t")
+          def printer
+            options.fetch(:output, CLI::CustomTablePrinter.new(FIELDS))
           end
         end
       end

--- a/spec/unit/cli/custom_table_printer_spec.rb
+++ b/spec/unit/cli/custom_table_printer_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe ThreeScaleToolbox::CLI::CustomTablePrinter do
+  let(:fields) { %w[my_field_name_a my_field_name_b] }
+  let(:record_a) { { 'my_field_name_a' => 11, 'my_field_name_b' => 22 } }
+  let(:record_b) { { 'my_field_name_a' => 33, 'my_field_name_b' => 44 } }
+
+  shared_examples 'header printed' do
+    it 'header_printed' do
+      expect { subject }.to output(/#{fields.map(&:upcase).join('\t')}/).to_stdout
+    end
+  end
+
+  context '#print_record' do
+    subject { described_class.new(fields).print_record(record_a) }
+
+    include_examples 'header printed'
+
+    it 'record_a printed' do
+      expect { subject }.to output(/#{record_a.values.join('\t')}/).to_stdout
+    end
+  end
+
+  context '#print_collection' do
+    subject { described_class.new(fields).print_collection([record_a, record_b]) }
+
+    include_examples 'header printed'
+
+    it 'record_a printed' do
+      expect { subject }.to output(/#{record_a.values.join('\t')}/).to_stdout
+    end
+
+    it 'record_b printed' do
+      expect { subject }.to output(/#{record_b.values.join('\t')}/).to_stdout
+    end
+  end
+end

--- a/spec/unit/commands/activedocs_command/apply_command_spec.rb
+++ b/spec/unit/commands/activedocs_command/apply_command_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Apply::ApplySubco
   let(:options) { default_options }
   let(:activedocs_ref) { "activedocsref" }
   let(:activedocs_id) { "1" }
+  let(:activedocs_attrs) { { 'id' => activedocs_id, "name" => activedocs_ref, "system_name" => activedocs_ref, "body" => activedocs_body_pretty_json } }
+  let(:activedocs_body_str) do
+    <<~YAML
+      ---
+      value1: "content1"
+    YAML
+  end
+  let(:activedocs_body_pretty_json) do
+    activedocs_body_content = YAML.safe_load(activedocs_body_str)
+    JSON.pretty_generate(activedocs_body_content)
+  end
   let(:arguments) do
     {
       remote: remote_name,
@@ -17,14 +28,14 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Apply::ApplySubco
   subject { described_class.new(options, arguments, nil) }
 
   before :example do
-    expect(subject).to receive(:threescale_client).with(remote_name).and_return(remote)
+    allow(activedocs).to receive(:attrs).and_return(activedocs_attrs)
+    allow(subject).to receive(:threescale_client).with(remote_name).and_return(remote)
   end
 
   context '#run' do
     context 'when --publish and --hide set' do
       let(:options) { default_options.merge(publish: true, hide: true) }
       it 'error raised' do
-        expect(activedocs_class).to receive(:find).with(remote: remote, ref: activedocs_ref).and_return(activedocs)
         expect { subject.run }.to raise_error(ThreeScaleToolbox::Error, /mutually exclusive/)
       end
     end
@@ -40,29 +51,25 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Apply::ApplySubco
     end
 
     context 'valid params' do
-      let(:activedocs_body_str) do
-        <<~YAML
-          ---
-          value1: "content1"
-        YAML
-      end
-      let(:activedocs_body_pretty_json) do
-        activedocs_body_content = YAML.safe_load(activedocs_body_str)
-        JSON.pretty_generate(activedocs_body_content)
-      end
       let(:general_options) { default_options.merge(:'openapi-spec' => "-") }
 
       context 'when activedocs not found' do
-        let(:activedocs_attrs) { { "name" => activedocs_ref, "system_name" => activedocs_ref, "body" => activedocs_body_pretty_json } }
+        let(:create_attrs) do
+          {
+            'name' => activedocs_ref,
+            'system_name' => activedocs_ref,
+            'body' => activedocs_body_pretty_json
+          }
+        end
         let(:options) { general_options }
         before :example do
           expect(activedocs_class).to receive(:find).with(remote: remote, ref: activedocs_ref).and_return(nil)
           expect(STDIN).to receive(:read).and_return(activedocs_body_str)
         end
+
         shared_examples 'activedocs created' do
           it do
-            expect(activedocs).to receive(:id).and_return(activedocs_id)
-            expect(activedocs_class).to receive(:create).with(remote: remote, attrs: activedocs_attrs).and_return(activedocs)
+            expect(activedocs_class).to receive(:create).with(remote: remote, attrs: create_attrs).and_return(activedocs)
             expect { subject.run }.to output(/Applied ActiveDocs id: #{activedocs_id}/).to_stdout
           end
         end
@@ -71,20 +78,19 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Apply::ApplySubco
 
         context 'when name in options' do
           let(:options) { general_options.merge(name: 'new name') }
-          let(:activedocs_attrs) { { "name" => options[:name], "system_name" => activedocs_ref, "body" => activedocs_body_pretty_json } }
+          let(:create_attrs) { { "name" => options[:name], "system_name" => activedocs_ref, "body" => activedocs_body_pretty_json } }
           include_examples 'activedocs created'
         end
 
         context 'when service-id in options' do
           let(:options) { general_options.merge(:'service-id' => '7') }
-          let(:activedocs_attrs) { { "service_id" => options[:'service-id'], "name" => activedocs_ref, "system_name" => activedocs_ref, "body" => activedocs_body_pretty_json } }
+          let(:create_attrs) { { "service_id" => options[:'service-id'], "name" => activedocs_ref, "system_name" => activedocs_ref, "body" => activedocs_body_pretty_json } }
           include_examples 'activedocs created'
         end
       end
 
       context 'when activedocs found' do
         before :example do
-          expect(activedocs).to receive(:id).and_return(activedocs_id)
           expect(activedocs_class).to receive(:find).with(remote: remote, ref: activedocs_ref).and_return(activedocs)
         end
 
@@ -96,7 +102,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Apply::ApplySubco
 
         context 'with options' do
           let(:options) { default_options.merge(name: 'some name', description: 'some descr', :'skip-swagger-validations' => true, :'service-id' => "5") }
-          let(:activedocs_attrs) do
+          let(:update_attrs) do
             {
               'name' => options[:name],
               'description' => options[:description],
@@ -106,7 +112,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Apply::ApplySubco
           end
 
           it 'activedocs updated' do
-            expect(activedocs).to receive(:update).with(activedocs_attrs)
+            expect(activedocs).to receive(:update).with(update_attrs)
             expect { subject.run }.to output(/Applied ActiveDocs id: #{activedocs_id}/).to_stdout
           end
         end

--- a/spec/unit/commands/activedocs_command/create_command_spec.rb
+++ b/spec/unit/commands/activedocs_command/create_command_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Create::CreateSub
     let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
     let(:activedocs_class) { class_double(ThreeScaleToolbox::Entities::ActiveDocs).as_stubbed_const }
     let(:activedocs) { instance_double(ThreeScaleToolbox::Entities::ActiveDocs) }
+    let(:activedocs_id) { 1 }
+    let(:activedocs_name) { 'a_activedocs_name' }
+    let(:activedocs_attrs) { { 'id' => activedocs_id, 'name' => activedocs_name } }
     let(:remote_name) { "myremote" }
 
     let(:options) { {} }
@@ -14,6 +17,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Create::CreateSub
     subject { described_class.new(options, arguments, nil) }
 
     before :example do
+      allow(activedocs).to receive(:attrs).and_return(activedocs_attrs)
       expect(subject).to receive(:threescale_client).with(remote_name).and_return(remote)
     end
 
@@ -34,8 +38,6 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Create::CreateSub
 
     context "activedocs name parameter and spec are specified" do
       let(:arguments) { { remote: remote_name, activedocs_name: activedocs_name, activedocs_spec: "-" } }
-      let(:activedocs_id) { "1" }
-      let(:activedocs_name) { "a_activedocs_name" }
       let(:activedoc_body_str) do
         <<~YAML
           ---
@@ -54,7 +56,6 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::Create::CreateSub
 
       shared_examples "successfully creates the activedocs with it" do
         it do
-          expect(activedocs).to receive(:id).and_return(activedocs_id)
           expect(STDIN).to receive(:read).and_return(activedoc_body_str)
           expect(activedocs_class).to receive(:create).with(activedocs_create_args).and_return(activedocs)
           expect do

--- a/spec/unit/commands/activedocs_command/list_command_spec.rb
+++ b/spec/unit/commands/activedocs_command/list_command_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ActiveDocsCommand::List::ListSubcomm
           let(:options) { {:'service-ref' => "name1"}}
 
           before :example do
-            expect(service_ref_filter_class). to receive(:new).with(remote, options[:'service-ref'], "service_id").and_return(service_ref_filter)
+            expect(service_ref_filter_class).to receive(:new).with(remote, options[:'service-ref'], "service_id").and_return(service_ref_filter)
             expect(service_ref_filter).to receive(:filter).with(activedocs_arr).and_return([activedocs_1])
           end
 

--- a/spec/unit/commands/application_command/apply_command_spec.rb
+++ b/spec/unit/commands/application_command/apply_command_spec.rb
@@ -13,11 +13,14 @@ RSpec.describe ThreeScaleToolbox::Commands::ApplicationCommand::Apply::ApplySubc
   let(:application_class) { class_double(ThreeScaleToolbox::Entities::Application).as_stubbed_const }
   let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:application) { instance_double(ThreeScaleToolbox::Entities::Application) }
+  let(:app_id) { 1 }
+  let(:app_attrs) { { 'id' => app_id } }
   subject { described_class.new(options, arguments, nil) }
 
   before :example do
     allow(service).to receive(:id).and_return(service_id)
     allow(account).to receive(:id).and_return(account_id)
+    allow(application).to receive(:attrs).and_return(app_attrs)
   end
 
   context '#run' do
@@ -36,7 +39,6 @@ RSpec.describe ThreeScaleToolbox::Commands::ApplicationCommand::Apply::ApplySubc
                                                          service_id: nil,
                                                          ref: app_ref)
                                                    .and_return(application)
-        expect(application).to receive(:id).and_return(1)
       end
 
       context 'no app attrs' do
@@ -305,7 +307,6 @@ RSpec.describe ThreeScaleToolbox::Commands::ApplicationCommand::Apply::ApplySubc
           expect(plan_class).to receive(:find).with(service: service, ref: 'myplan')
                                               .and_return(plan)
           expect(plan).to receive(:id).and_return('planId')
-          expect(application).to receive(:id).and_return(1)
         end
 
         it 'user_key set to application param' do

--- a/spec/unit/commands/application_command/create_command_spec.rb
+++ b/spec/unit/commands/application_command/create_command_spec.rb
@@ -17,10 +17,16 @@ RSpec.describe ThreeScaleToolbox::Commands::ApplicationCommand::Create::CreateSu
   let(:plan) { instance_double(ThreeScaleToolbox::Entities::ApplicationPlan) }
   let(:application_class) { class_double(ThreeScaleToolbox::Entities::Application).as_stubbed_const }
   let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
+  let(:app0_id) { 200 }
+  let(:app0_attrs) { { 'id' => app0_id } }
   let(:app0) { instance_double(ThreeScaleToolbox::Entities::Application) }
   subject { described_class.new(options, arguments, nil) }
 
   context '#run' do
+    before :each do
+      allow(app0).to receive(:attrs).and_return(app0_attrs)
+    end
+
     context 'when account not found' do
       let(:account) { nil }
 
@@ -85,7 +91,6 @@ RSpec.describe ThreeScaleToolbox::Commands::ApplicationCommand::Create::CreateSu
         expect(plan_class).to receive(:find).with(service: service, ref: 'myplan')
                                             .and_return(plan)
         expect(plan).to receive(:id).and_return(100)
-        expect(app0).to receive(:id).and_return(200)
       end
 
       it 'application belongs to given plan' do

--- a/spec/unit/commands/application_command/show_command_spec.rb
+++ b/spec/unit/commands/application_command/show_command_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ThreeScaleToolbox::Commands::ApplicationCommand::Show::ShowSubcommand do
   let(:arguments) { { application: 'someapp', remote: 'https://key@destination.example.com' } }
-  let(:options) {}
+  let(:options) { {} }
   let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
   let(:application_class) { class_double(ThreeScaleToolbox::Entities::Application).as_stubbed_const }
   let(:application) { instance_double(ThreeScaleToolbox::Entities::Application) }

--- a/spec/unit/commands/methods_command/apply_command_spec.rb
+++ b/spec/unit/commands/methods_command/apply_command_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Apply::ApplySubcomma
   let(:method) { instance_double(ThreeScaleToolbox::Entities::Method) }
   let(:hits_id) { 1 }
   let(:hits) { { 'id' => hits_id } }
+  let(:method_id) { 1 }
+  let(:method_attrs) { { 'id' => method_id } }
   subject { described_class.new(options, arguments, nil) }
 
   context '#run' do
@@ -27,6 +29,7 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Apply::ApplySubcomma
       before :example do
         expect(service_class).to receive(:find).and_return(service)
         expect(subject).to receive(:threescale_client).and_return(remote)
+        allow(method).to receive(:attrs).and_return(method_attrs)
       end
 
       context 'when service not found' do
@@ -39,7 +42,7 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Apply::ApplySubcomma
       end
 
       context 'when method not found' do
-        let(:method_attrs) do
+        let(:create_attrs) do
           {
             'friendly_name' => arguments[:method_ref],
             'system_name' => arguments[:method_ref]
@@ -52,20 +55,19 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Apply::ApplySubcomma
                                                       parent_id: hits_id,
                                                       ref: arguments[:method_ref])
                                                 .and_return(nil)
-          expect(method).to receive(:id).and_return(1)
         end
 
         it 'method created' do
           expect(method_class).to receive(:create).with(service: service,
                                                         parent_id: hits_id,
-                                                        attrs: method_attrs)
+                                                        attrs: create_attrs)
                                                   .and_return(method)
           expect { subject.run }.to output(/Applied method id: 1/).to_stdout
         end
 
         context 'when name in options' do
           let(:options) { { name: 'new name' } }
-          let(:method_attrs) do
+          let(:create_attrs) do
             {
               'friendly_name' => options[:name],
               'system_name' => arguments[:method_ref]
@@ -75,7 +77,7 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Apply::ApplySubcomma
           it 'friendly_name overriden' do
             expect(method_class).to receive(:create).with(service: service,
                                                           parent_id: hits_id,
-                                                          attrs: method_attrs)
+                                                          attrs: create_attrs)
                                                     .and_return(method)
             expect { subject.run }.to output(/Applied method id: 1/).to_stdout
           end
@@ -89,7 +91,6 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Apply::ApplySubcomma
                                                       parent_id: hits_id,
                                                       ref: arguments[:method_ref])
                                                 .and_return(method)
-          expect(method).to receive(:id).and_return(1)
         end
 
         context 'with no options' do
@@ -102,7 +103,7 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Apply::ApplySubcomma
 
         context 'with options' do
           let(:options) { { name: 'some name', description: 'some descr' } }
-          let(:method_attrs) do
+          let(:update_attrs) do
             {
               'friendly_name' => options[:name],
               'description' => options[:description]
@@ -110,7 +111,7 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Apply::ApplySubcomma
           end
 
           it 'method updated' do
-            expect(method).to receive(:update).with(method_attrs)
+            expect(method).to receive(:update).with(update_attrs)
             expect { subject.run }.to output(/Applied method id: 1/).to_stdout
           end
         end

--- a/spec/unit/commands/methods_command/create_command_spec.rb
+++ b/spec/unit/commands/methods_command/create_command_spec.rb
@@ -14,12 +14,15 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Create::CreateSubcom
   let(:hits_id) { 1 }
   let(:hits) { { 'id' => hits_id } }
   let(:expected_basic_attrs) { { 'friendly_name' => arguments[:method_name] } }
+  let(:method_id) { 1 }
+  let(:method_attrs) { { 'id' => method_id } }
   subject { described_class.new(options, arguments, nil) }
 
   context '#run' do
     before :example do
-      expect(service_class).to receive(:find).and_return(service)
       expect(subject).to receive(:threescale_client).and_return(remote)
+      expect(service_class).to receive(:find).and_return(service)
+      allow(method).to receive(:attrs).and_return(method_attrs)
     end
 
     context 'when service not found' do
@@ -39,7 +42,6 @@ RSpec.describe ThreeScaleToolbox::Commands::MethodsCommand::Create::CreateSubcom
                                                       parent_id: hits_id,
                                                       attrs: expected_attrs)
                                                 .and_return(method)
-        expect(method).to receive(:id).and_return('1')
       end
 
       it do

--- a/spec/unit/commands/metrics_command/create_command_spec.rb
+++ b/spec/unit/commands/metrics_command/create_command_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe ThreeScaleToolbox::Commands::MetricsCommand::Create::CreateSubcom
   let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
   let(:metric_class) { class_double(ThreeScaleToolbox::Entities::Metric).as_stubbed_const }
   let(:metric) { instance_double(ThreeScaleToolbox::Entities::Metric) }
+  let(:metric_id) { 1 }
+  let(:metric_attrs) { { 'id' => metric_id } }
   let(:expected_basic_attrs) do
     {
       'friendly_name' => arguments[:metric_name],
@@ -23,6 +25,7 @@ RSpec.describe ThreeScaleToolbox::Commands::MetricsCommand::Create::CreateSubcom
     before :example do
       expect(service_class).to receive(:find).and_return(service)
       expect(subject).to receive(:threescale_client).and_return(remote)
+      allow(metric).to receive(:attrs).and_return(metric_attrs)
     end
 
     context 'when service not found' do
@@ -39,7 +42,6 @@ RSpec.describe ThreeScaleToolbox::Commands::MetricsCommand::Create::CreateSubcom
       before :example do
         expect(metric_class).to receive(:create).with(service: service, attrs: expected_attrs)
                                                 .and_return(metric)
-        expect(metric).to receive(:id).and_return('1')
       end
 
       it do

--- a/spec/unit/commands/plans_command/apply_command_spec.rb
+++ b/spec/unit/commands/plans_command/apply_command_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Apply::ApplySubcommand
     }
   end
   let(:options) { {} }
+  let(:plan_id) { 1 }
   let(:basic_plan_attrs) { { 'name' => 'someplan' } }
+  let(:plan_attrs) { basic_plan_attrs.merge('id' => plan_id) }
   let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
@@ -33,6 +35,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Apply::ApplySubcommand
       before :example do
         expect(service_class).to receive(:find).and_return(service)
         expect(subject).to receive(:threescale_client).and_return(remote)
+        allow(plan).to receive(:attrs).and_return(plan_attrs)
       end
 
       context 'when service not found' do
@@ -45,15 +48,14 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Apply::ApplySubcommand
       end
 
       context 'when plan not found' do
-        let(:plan_attrs) { { 'name' => 'someplan', 'system_name' => 'someplan' } }
+        let(:create_attrs) { { 'name' => 'someplan', 'system_name' => 'someplan' } }
 
         before :example do
           expect(plan_class).to receive(:find).and_return(nil)
-          expect(plan).to receive(:id).and_return(1)
         end
 
         it 'plan created' do
-          expect(plan_class).to receive(:create).with(service: service, plan_attrs: plan_attrs)
+          expect(plan_class).to receive(:create).with(service: service, plan_attrs: create_attrs)
                                                 .and_return(plan)
           expect { subject.run }.to output(/Applied application plan id: 1/).to_stdout
         end
@@ -63,7 +65,6 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Apply::ApplySubcommand
         let(:current_attrs) { {} }
         before :example do
           expect(plan_class).to receive(:find).and_return(plan)
-          expect(plan).to receive(:id).and_return(1)
         end
 
         context 'with no options' do
@@ -83,7 +84,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Apply::ApplySubcommand
               'trial-period-days': 2
             }
           end
-          let(:plan_attrs) do
+          let(:update_attrs) do
             {
               'approval_required' => 'b',
               'cost_per_month' => 0,
@@ -93,7 +94,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Apply::ApplySubcommand
           end
 
           it 'plan updated' do
-            expect(plan).to receive(:update).with(plan_attrs)
+            expect(plan).to receive(:update).with(update_attrs)
             expect { subject.run }.to output(/Applied application plan id: 1/).to_stdout
           end
         end

--- a/spec/unit/commands/plans_command/create_command_spec.rb
+++ b/spec/unit/commands/plans_command/create_command_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Create::CreateSubcomma
     }
   end
   let(:options) { {} }
+  let(:plan_id) { 1 }
   let(:basic_plan_attrs) { { 'name' => 'someplan' } }
+  let(:plan_attrs) { basic_plan_attrs.merge('id' => plan_id) }
   let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }
@@ -17,6 +19,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Create::CreateSubcomma
   context '#run' do
     before :example do
       expect(service_class).to receive(:find).and_return(service)
+      allow(plan).to receive(:attrs).and_return(plan_attrs)
       expect(subject).to receive(:threescale_client).and_return(remote)
     end
 
@@ -30,12 +33,11 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Create::CreateSubcomma
     end
 
     context 'when app plan created' do
-      let(:plan_attrs) { basic_plan_attrs }
+      let(:create_attrs) { basic_plan_attrs }
 
       before :example do
-        expect(plan_class).to receive(:create).with(service: service, plan_attrs: plan_attrs)
+        expect(plan_class).to receive(:create).with(service: service, plan_attrs: create_attrs)
                                               .and_return(plan)
-        expect(plan).to receive(:id).and_return('1')
       end
 
       it do
@@ -62,7 +64,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Create::CreateSubcomma
 
       context 'with publish option' do
         let(:options) { { publish: true } }
-        let(:plan_attrs) { basic_plan_attrs.merge('state' => 'published') }
+        let(:create_attrs) { basic_plan_attrs.merge('state' => 'published') }
 
         it 'plan made public' do
           expect { subject.run }.to output(/Created application plan id: 1/).to_stdout
@@ -89,7 +91,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Create::CreateSubcomma
             'trial_period_days' => 2
           }
         end
-        let(:plan_attrs) { basic_plan_attrs.merge(expected_params) }
+        let(:create_attrs) { basic_plan_attrs.merge(expected_params) }
 
         it 'plan created with expected params' do
           expect { subject.run }.to output(/Created application plan id: 1/).to_stdout

--- a/spec/unit/commands/plans_command/list_command_spec.rb
+++ b/spec/unit/commands/plans_command/list_command_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::List::ListSubcommand d
       service_ref: 'someservice', remote: 'https://destination_key@destination.example.com'
     }
   end
-  let(:options) {}
+  let(:options) { {} }
   let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }

--- a/spec/unit/commands/plans_command/show_command_spec.rb
+++ b/spec/unit/commands/plans_command/show_command_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ThreeScaleToolbox::Commands::PlansCommand::Show::ShowSubcommand d
       remote: 'https://destination_key@destination.example.com'
     }
   end
-  let(:options) {}
+  let(:options) { {} }
   let(:remote) { instance_double('ThreeScale::API::Client', 'remote') }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service) { instance_double('ThreeScaleToolbox::Entities::Service') }

--- a/spec/unit/commands/proxy_config_command/show_command_spec.rb
+++ b/spec/unit/commands/proxy_config_command/show_command_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ProxyConfigCommand::Show::ShowSubcom
     let(:proxy_config_env) { "production" }
     let(:remote_name) { "myremote" }
     let(:arguments) { {remote: remote_name, service: service_ref , environment: proxy_config_env} }
-    let(:options) { {} }
+    let(:options) { { 'config-version': 'latest' } }
 
     subject { described_class.new(options, arguments, nil) }
 

--- a/spec/unit/commands/service_command/create_command_spec.rb
+++ b/spec/unit/commands/service_command/create_command_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe ThreeScaleToolbox::Commands::ServiceCommand::Create::CreateSubcom
     let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
     let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
     let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
+    let(:service_id) { 1 }
+    let(:service_name) { 'some_name' }
+    let(:service_attrs) { { 'id' => service_id, 'name' => service_name } }
     let(:remote_name) { "myremote" }
 
     let(:options) { {} }
@@ -12,6 +15,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ServiceCommand::Create::CreateSubcom
     subject { described_class.new(options, arguments, nil) }
 
     before :example do
+      allow(service).to receive(:attrs).and_return(service_attrs)
       expect(subject).to receive(:threescale_client).with(remote_name).and_return(remote)
     end
 
@@ -34,10 +38,8 @@ RSpec.describe ThreeScaleToolbox::Commands::ServiceCommand::Create::CreateSubcom
       let(:service_name) { "a_service_name" }
       let(:service_create_params) { { "name" => service_name } }
       let(:service_create_args) { { remote: remote, service_params: service_create_params } }
-      let(:service_id) { "1" }
       shared_examples "successfully creates the service with it" do
         it do
-          expect(service).to receive(:id).and_return(service_id)
           expect(service_class).to receive(:create).with(service_create_args).and_return(service)
           expect do
             subject.run

--- a/spec/unit/commands/service_command/list_command_spec.rb
+++ b/spec/unit/commands/service_command/list_command_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ServiceCommand::List::ListSubcommand
     let(:remote) { instance_double(ThreeScale::API::Client, 'remote') }
     let(:remote_name) { "myremote" }
 
-    let(:options) {}
+    let(:options) { {} }
     let(:arguments) { { remote: remote_name } }
 
     subject { described_class.new(options, arguments, nil) }

--- a/spec/unit/commands/service_command/show_command_spec.rb
+++ b/spec/unit/commands/service_command/show_command_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ServiceCommand::Show::ShowSubcommand
     let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
     let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
     let(:remote_name) { "myremote" }
-    let(:options) {}
+    let(:options) { {} }
 
     subject { described_class.new(options, arguments, nil) }
 


### PR DESCRIPTION
Added a new option:
```
    -o --output=<value>              Output format. One of: json|yaml
```
to the following commands:

- [x] method list, apply, create commands
- [x] application plans create, apply, list, show commands
- [x] metric list, apply, create commands
- [x] activedocs list, apply, create commands
- [x] application list, create, show, apply commands
- [x] service list, create, show, apply commands
- [x] proxy-config list, show commands

Other work done:

- [x] Unittests
- [x] Update doc