### PR TITLE
Deprecate ruby 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,6 @@ commands:
           command: |
             bundle exec rake spec:unit
 jobs:
-  ruby-246-unittest:
-    docker:
-      - image: circleci/ruby:2.4.6
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - unittests
-
   ruby-255-unittest:
     docker:
       - image: circleci/ruby:2.5.5
@@ -91,7 +83,6 @@ workflows:
   version: 2
   basic_tests:
     jobs:
-      - ruby-246-unittest
       - ruby-255-unittest
       - ruby-262-unittest
       - license_check

--- a/3scale_toolbox.gemspec
+++ b/3scale_toolbox.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'webmock', '~> 3.4'
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_dependency '3scale-api', '~> 0.6.0'
   spec.add_dependency 'cri', '~> 2.15'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ See the LICENSE and NOTICE files that should have been provided along with this 
 3scale toolbox is a set of tools to help you manage your 3scale product. Using the [3scale API Ruby Client](https://github.com/3scale/3scale-api-ruby).
 
 ## Table of contents
+* [Requirements](#requirements)
 * [Installation](#installation)
 * [Usage](#usage)
    * [Copy a service](docs/copy-service.md)
@@ -31,6 +32,12 @@ See the LICENSE and NOTICE files that should have been provided along with this 
 * [Plugins](#plugins)
 * [Troubleshooting](#troubleshooting)
 * [Contributing](#contributing)
+
+## Requirements
+Supported Ruby interpreters
+
+* MRI 2.5
+* MRI 2.6
 
 ## Installation
 Install the toolbox:
@@ -189,7 +196,7 @@ $ 3scale service_list my-3scale-instance
 
 It is a requirement that we include a file describing all the licenses used in the product, so that users can examine it.
 
-Run `rake license_finder:check` to check licenses when dependencies change. 
+Run `rake license_finder:check` to check licenses when dependencies change.
 
 Run `rake license_finder:report > licenses.xml` to update licenses file.
 


### PR DESCRIPTION
ruby 2.4 is almost in EOL date: 2020-03-31
~Support ruby 2.7~