### PR TITLE
Threescale 669: Export apicast configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
    * Create, Apply, List, Delete [Method](docs/method.md)
    * Create, Apply, List, Show, Delete [Service](docs/service.md)
    * Create, Apply, List, Delete [ActiveDocs](docs/activedocs.md)
-   * List, Show, Promote [Proxy Configuration](docs/proxy-config.md)
+   * List, Show, Promote, Export [Proxy Configuration](docs/proxy-config.md)
    * [Copy Policy Registry](docs/copy-policy-registry.md)
    * Create, Apply, List, Show, Delete, Suspend, Resume [Applications](docs/applications.md)
    * [Remotes](docs/remotes.md)

--- a/docs/proxy-config.md
+++ b/docs/proxy-config.md
@@ -3,6 +3,7 @@
 * [List Proxy Configurations](#list)
 * [Show Proxy Configuration](#show)
 * [Promote Proxy Configuration](#promote)
+* [Export Proxy Configuration](#export)
 
 ### List
 
@@ -80,4 +81,27 @@ OPTIONS FOR PROXY-CONFIG
                                   connections otherwise considered insecure
     -v --version                  Prints the version of this command
        --verbose                  Verbose mode
+```
+
+### Export
+
+```shell
+NAME
+    export - Export proxy configuration for the entire provider account
+
+USAGE
+    3scale proxy-config export <remote>
+
+DESCRIPTION
+    Export proxy configuration for the entire provider account
+
+    Can be used as 3scale apicast configuration file
+
+
+    https://github.com/3scale/apicast/blob/master/doc/parameters.md#threescale_config_file
+
+OPTIONS
+       --environment=<value>      Gateway environment. Must be 'sandbox' or
+                                  'production' (default: sandbox)
+    -o --output=<value>           Output format. One of: json|yaml
 ```

--- a/lib/3scale_toolbox/commands/proxy_config_command.rb
+++ b/lib/3scale_toolbox/commands/proxy_config_command.rb
@@ -1,8 +1,10 @@
 require 'cri'
 require '3scale_toolbox/base_command'
+require '3scale_toolbox/commands/proxy_config_command/helper'
 require '3scale_toolbox/commands/proxy_config_command/list_command'
 require '3scale_toolbox/commands/proxy_config_command/show_command'
 require '3scale_toolbox/commands/proxy_config_command/promote_command'
+require '3scale_toolbox/commands/proxy_config_command/export_command'
 
 module ThreeScaleToolbox
   module Commands
@@ -25,6 +27,7 @@ module ThreeScaleToolbox
       add_subcommand(List::ListSubcommand)
       add_subcommand(Show::ShowSubcommand)
       add_subcommand(Promote::PromoteSubcommand)
+      add_subcommand(Export::ExportSubcommand)
     end
   end
 end

--- a/lib/3scale_toolbox/commands/proxy_config_command/export_command.rb
+++ b/lib/3scale_toolbox/commands/proxy_config_command/export_command.rb
@@ -1,0 +1,76 @@
+module ThreeScaleToolbox
+  module Commands
+    module ProxyConfigCommand
+      module Export
+        class ExportSubcommand < Cri::CommandRunner
+          include ThreeScaleToolbox::Command
+
+          def self.command
+            Cri::Command.define do
+              name        'export'
+              usage       'export <remote>'
+              summary     'Export proxy configuration for the entire provider account'
+              description <<-HEREDOC
+              Export proxy configuration for the entire provider account
+              \n Can be used as 3scale apicast configuration file
+              \n https://github.com/3scale/apicast/blob/master/doc/parameters.md#threescale_config_file
+              HEREDOC
+
+              param :remote
+
+              ThreeScaleToolbox::CLI.output_flag(self)
+              option nil, :environment, "Gateway environment. Must be 'sandbox' or 'production'", default: 'sandbox', argument: :required, transform: ProxyConfigCommand::EnvironmentTransformer.new
+
+              runner ExportSubcommand
+            end
+          end
+
+          def run
+            printer.print_record proxy_config_list_obj
+          end
+
+          private
+
+          def proxy_config_list_obj
+            {
+              'services' => proxy_config_list
+            }
+          end
+
+          def proxy_config_list
+            service_list.map do |service|
+              pc = Entities::ProxyConfig.find_latest(service: service, environment: environment)
+              raise ThreeScaleToolbox::Error, "ProxyConfig for environment #{environment} in service #{service.id} does not exist" if pc.nil?
+
+              pc.attrs['content']
+            end
+          end
+
+          def service_list
+            tmp_list = remote.list_services
+
+            if tmp_list.respond_to?(:has_key?) && (errors = tmp_list['errors'])
+              raise ThreeScaleToolbox::ThreeScaleApiError.new('Service list not read', errors)
+            end
+
+            tmp_list.map do |svc_attrs|
+              Entities::Service.new(id: svc_attrs.fetch('id'), remote: remote, attrs: svc_attrs)
+            end
+          end
+
+          def remote
+            @remote ||= threescale_client(arguments[:remote])
+          end
+
+          def environment
+            options[:environment]
+          end
+
+          def printer
+            options.fetch(:output, CLI::JsonPrinter.new)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/proxy_config_command/helper.rb
+++ b/lib/3scale_toolbox/commands/proxy_config_command/helper.rb
@@ -1,0 +1,15 @@
+module ThreeScaleToolbox
+  module Commands
+    module ProxyConfigCommand
+      class EnvironmentTransformer
+        def call(param_str)
+          raise ArgumentError unless param_str.is_a?(String)
+
+          raise ArgumentError unless %w[production sandbox].include? param_str
+
+          param_str
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands/proxy_config_command/export_command_spec.rb
+++ b/spec/unit/commands/proxy_config_command/export_command_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe ThreeScaleToolbox::Commands::ProxyConfigCommand::Export::ExportSubcommand do
+  context '#run' do
+    let(:remote) { instance_double(ThreeScale::API::Client) }
+    let(:proxy_config_env) { 'production' }
+    let(:remote_name) { 'myremote' }
+    let(:arguments) { { remote: remote_name } }
+    let(:options) { { environment: proxy_config_env } }
+    let(:svc_a_attrs) { { 'id' => '1' } }
+    let(:svc_b_attrs) { { 'id' => '2' } }
+    let(:content_a) { { 'some_attr' => 'A' } }
+    let(:content_b) { { 'some_attr' => 'B' } }
+    let(:proxy_conf_a) { { 'id' => '1', 'version' => 23, 'content' => content_a } }
+    let(:proxy_conf_b) { { 'id' => '2', 'version' => 13, 'content' => content_b } }
+    let(:service_list_attrs) { [svc_a_attrs, svc_b_attrs] }
+    let(:pretty_printed_configs) { JSON.pretty_generate('services' => [content_a, content_b]) + "\n" }
+
+    let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+    let(:proxy_config_class) { class_double(ThreeScaleToolbox::Entities::ProxyConfig).as_stubbed_const }
+    let(:proxy_config) { instance_double(ThreeScaleToolbox::Entities::ProxyConfig) }
+    let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
+
+    subject { described_class.new(options, arguments, nil) }
+
+    before :example do
+      expect(subject).to receive(:threescale_client).with(remote_name).and_return(remote)
+      expect(remote).to receive(:list_services).and_return(service_list_attrs)
+      expect(remote).to receive(:proxy_config_latest).with(1, proxy_config_env).and_return(proxy_conf_a)
+      expect(remote).to receive(:proxy_config_latest).with(2, proxy_config_env).and_return(proxy_conf_b)
+    end
+
+    it 'exports proxy config for all products' do
+      expect { subject.run }.to output(pretty_printed_configs).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
New `proxy-config` subcommand: `export`.

Export proxy configuration to be used as 3scale apicast configuration: https://issues.redhat.com/browse/THREESCALE-669

```
$3scale proxy-config export -h
NAME
    export - Export proxy configuration for the entire provider account

USAGE
    3scale proxy-config export <remote>

DESCRIPTION
    Export proxy configuration for the entire provider account

    Can be used as 3scale apicast configuration file

    
    https://github.com/3scale/apicast/blob/master/doc/parameters.md#threescale_config_file

OPTIONS
       --environment=<value>      Gateway environment. Must be 'sandbox' or
                                  'production' (default: sandbox)
    -o --output=<value>           Output format. One of: json|yaml
```