### PR TITLE
service copy command fix: do not copy endpoint url hosted services

### DIFF
--- a/docs/copy-product.md
+++ b/docs/copy-product.md
@@ -7,7 +7,7 @@ If a product with the selected `system-name` is not found, it will be created.
 
 Components of the backend being copied:
 * product configuration
-* product settings
+* product settings: Staging/Production Public Base URL only copied for self-managed deployments.
 * product methods&metrics: Only missing metrics&methods will be created.
 * product mapping rules: Only missing mapping rules will be created.
 * product application plans & pricing rules & limits: Only missing application plans & pricing rules & limits will be created.

--- a/docs/copy-service.md
+++ b/docs/copy-service.md
@@ -8,6 +8,7 @@ Components of the service being copied:
 
 * service settings
 * proxy settings
+* proxy settings: Staging/Production Public Base URL only copied for self-managed deployments.
 * pricing rules
 * activedocs
 * metrics

--- a/lib/3scale_toolbox/commands/service_command/copy_command/copy_service_proxy_task.rb
+++ b/lib/3scale_toolbox/commands/service_command/copy_command/copy_service_proxy_task.rb
@@ -6,9 +6,25 @@ module ThreeScaleToolbox
           include Task
 
           def call
-            target.update_proxy source.proxy
+            target.update_proxy target_proxy_attrs
             target.update_oidc source.oidc if source.attrs['backend_version'] == 'oidc'
             puts "updated proxy of #{target.id} to match the original"
+          end
+
+          def target_proxy_attrs
+            if source.attrs['deployment_option'] == 'hosted'
+              # for services with "hosted" deployment config,
+              # apicast gateway addresses should not be copied.
+              # Gateway addresses includes service's id and if copied, the service will not
+              # have visibility.
+              source_proxy.dup.delete_if { |key, _v| %w[endpoint sandbox_endpoint].include? key }
+            else
+              source_proxy
+            end
+          end
+
+          def source_proxy
+            @source_proxy ||= source.proxy
           end
         end
       end

--- a/lib/3scale_toolbox/commands/service_command/copy_command/copy_service_proxy_task.rb
+++ b/lib/3scale_toolbox/commands/service_command/copy_command/copy_service_proxy_task.rb
@@ -13,10 +13,9 @@ module ThreeScaleToolbox
 
           def target_proxy_attrs
             if source.attrs['deployment_option'] == 'hosted'
-              # for services with "hosted" deployment config,
-              # apicast gateway addresses should not be copied.
-              # Gateway addresses includes service's id and if copied, the service will not
-              # have visibility.
+              # For services with "hosted" deployment config, 
+              # "Public Base URL" should not be copied, mainly because public base URL is self-assigned.
+              # Two 3scale products (aka services) cannot be served using the same public base URL.
               source_proxy.dup.delete_if { |key, _v| %w[endpoint sandbox_endpoint].include? key }
             else
               source_proxy


### PR DESCRIPTION
Service copy command: do not copy endpoint url for services with hosted gateway