### PR TITLE
fix proxy config integration tests

### DIFF
--- a/spec/integration/commands/proxy_config_command/list_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/list_command_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'ProxyConfig List command' do
     before :example do
       svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
 
-      svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage1" })
+      # Service needs backend api. Otherwise proxy config will not be promoted to sandbox
+      svc.update_proxy('api_backend' => 'https://example.com')
       pc_sandbox_1 = nil
       Helpers.wait do
         pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)

--- a/spec/integration/commands/proxy_config_command/promote_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/promote_command_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe 'ProxyConfig Promote command' do
     context "That hasn't been promoted" do
       before :example do
         svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
-        svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage1" })
+        # Service needs backend api. Otherwise proxy config will not be promoted to sandbox
+        svc.update_proxy('api_backend' => 'https://example.com')
       end
       after :example do
         res = ThreeScaleToolbox::Entities::Service::find(remote: api3scale_client, ref: service_ref)
@@ -30,7 +31,8 @@ RSpec.describe 'ProxyConfig Promote command' do
     context "That has already been promoted" do
       before :example do
         svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
-        svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage1" })
+        # Service needs backend api. Otherwise proxy config will not be promoted to sandbox
+        svc.update_proxy('api_backend' => 'https://example.com')
         pc_sandbox_1 = nil
         Helpers.wait do
           pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)

--- a/spec/integration/commands/proxy_config_command/show_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/show_command_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe 'ProxyConfig Show command' do
   context "With the specified service existing" do
     before :example do
       svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
-
-      svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage1" })
+      # Service needs backend api. Otherwise proxy config will not be promoted to sandbox
+      svc.update_proxy('api_backend' => 'https://example.com')
       pc_sandbox_1 = nil
       Helpers.wait do
         pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -101,6 +101,7 @@ RSpec.shared_context :import_oas_real_cleanup do
     # backend cannot be deleted if used by any product
     # remove first product
     service.delete
+    Helpers.wait { ThreeScaleToolbox::Entities::Service.find(remote: api3scale_client, ref: service.id).nil? }
     backend_usage_list.each do |backend_usage|
       backend = ThreeScaleToolbox::Entities::Backend.find(remote: api3scale_client, ref: backend_usage.backend_id)
       backend.delete unless backend.nil?


### PR DESCRIPTION
 Service needs backend api. Otherwise proxy config will not be promoted to sandbox. This behavior was changed when APIaP was implemented.

