### PR TITLE
oas3: fix custom ports for backend url

### DIFF
--- a/lib/3scale_toolbox/openapi/oas3.rb
+++ b/lib/3scale_toolbox/openapi/oas3.rb
@@ -64,7 +64,7 @@ module ThreeScaleToolbox
 
       def host
         # If there are many? take first
-        server_objects(&:host).first
+        server_objects { |url| "#{url.host}:#{url.port}" }.first
       end
 
       def scheme

--- a/spec/shared_oas3_contexts.rb
+++ b/spec/shared_oas3_contexts.rb
@@ -37,6 +37,25 @@ RSpec.shared_context :oas3_resources do
     YAML
   end
 
+  let(:servers_port_oas3_content) do
+    <<~YAML
+      ---
+      openapi: "3.0.0"
+      info:
+        title: "some title"
+        version: "1.0.0"
+      servers:
+        - url: https://petstore.swagger.io:8080/v1
+      paths:
+        /pet:
+          get:
+            operationId: "getPet"
+            responses:
+              405:
+                description: "invalid input"
+    YAML
+  end
+
   let(:server_templates_oas3_content) do
     <<~YAML
       ---

--- a/spec/unit/openapi/oas3_spec.rb
+++ b/spec/unit/openapi/oas3_spec.rb
@@ -117,7 +117,15 @@ RSpec.describe ThreeScaleToolbox::OpenAPI::OAS3 do
       let(:content) { servers_oas3_content }
 
       it 'only first element taken' do
-        expect(subject.host).to eq('petstore.swagger.io')
+        expect(subject.host).to eq('petstore.swagger.io:443')
+      end
+    end
+
+    context 'includes port' do
+      let(:content) { servers_port_oas3_content }
+
+      it do
+        expect(subject.host).to eq('petstore.swagger.io:8080')
       end
     end
 
@@ -125,7 +133,7 @@ RSpec.describe ThreeScaleToolbox::OpenAPI::OAS3 do
       let(:content) { server_templates_oas3_content }
 
       it 'template rendered' do
-        expect(subject.host).to eq('petstorev1.swagger.io')
+        expect(subject.host).to eq('petstorev1.swagger.io:443')
       end
     end
   end


### PR DESCRIPTION
When importing an OAS 3.0.2 spec, the 3scale toolbox converts custom ports to the default protocol (e.g. 80/HTTP) in the Backend definition

https://issues.redhat.com/browse/THREESCALE-6192