### PR TITLE
policies command, import and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
    * List, Show, Promote, Export [Proxy Configuration](docs/proxy-config.md)
    * [Copy Policy Registry](docs/copy-policy-registry.md)
    * Create, Apply, List, Show, Delete, Suspend, Resume [Applications](docs/applications.md)
+   * [Export/Import Product Policy Chain](docs/export-import-policy-chain.md)
    * [Remotes](docs/remotes.md)
 * [Development](#development)
    * [Testing](#testing)

--- a/docs/export-import-policy-chain.md
+++ b/docs/export-import-policy-chain.md
@@ -1,0 +1,70 @@
+## Export/Import Product Policy Chain
+
+Common description:
+* Export/Import one product's policy chain to/from yaml/json content.
+* Product can be referenced by `id` or `system_name`.
+
+Specific to `export` command:
+* Read only operation on remote product.
+* Command `output` can be `stdout` or file. If not specified by `-f` option, by default, content will be written on `stdout`.
+* Command output format can be `json` or `yaml` using `-o` option. Defaults to `yaml`
+
+Specific to `import` command:
+* Imported content can be `stdin` (by default), file (`-f` option) or URL (`-u` option).
+* Imported content can be `yaml` or `json`. No need to specify the format, the content format will be detected automatically.
+* Imported resource as the source of truth. The existing policy chain will be updated with the imported new one. `SET` semantics implemented.
+* All content validation is delegated to the 3scale API.
+
+### Export Product Policy Chain
+
+```shell
+NAME
+    export - export product policy chain
+
+USAGE
+    3scale policies export [opts] <remote>
+    <product>
+
+DESCRIPTION
+    export product policy chain
+
+OPTIONS
+    -f --file=<value>             Write to file instead of stdout
+    -o --output=<value>           Output format. One of: json|yaml
+```
+
+### Import Product Policy Chain
+
+```shell
+NAME
+    import - import product policy chain
+
+USAGE
+    3scale policies import [opts] <remote>
+    <product>
+
+DESCRIPTION
+    import product policy chain
+
+OPTIONS
+    -f --file=<value>             Read from file
+    -u --url=<value>              Read from url
+```
+
+### Export policy chain to a file in yaml
+
+```shell
+$ 3scale policies export -f policies.yaml -o yaml remote_name product_name
+```
+
+### Import policy chain from a file
+
+```shell
+$ 3scale policies import -f plan.yaml remote_name product_name
+```
+
+### Import policy chain from URI
+
+```shell
+$ 3scale policies import -f http[s]://domain/resource/path.yaml remote_name product_name
+```

--- a/lib/3scale_toolbox/commands.rb
+++ b/lib/3scale_toolbox/commands.rb
@@ -15,6 +15,7 @@ require '3scale_toolbox/commands/policy_registry_command'
 require '3scale_toolbox/commands/application_command'
 require '3scale_toolbox/commands/backend_command'
 require '3scale_toolbox/commands/product_command'
+require '3scale_toolbox/commands/policies_command'
 
 module ThreeScaleToolbox
   module Commands
@@ -35,6 +36,7 @@ module ThreeScaleToolbox
       ThreeScaleToolbox::Commands::ApplicationCommand,
       ThreeScaleToolbox::Commands::BackendCommand,
       ThreeScaleToolbox::Commands::ProductCommand,
+      ThreeScaleToolbox::Commands::PoliciesCommand,
     ].freeze
   end
 end

--- a/lib/3scale_toolbox/commands/policies_command.rb
+++ b/lib/3scale_toolbox/commands/policies_command.rb
@@ -1,0 +1,24 @@
+require '3scale_toolbox/commands/policies_command/export_command'
+require '3scale_toolbox/commands/policies_command/import_command'
+
+module ThreeScaleToolbox
+  module Commands
+    module PoliciesCommand
+      include ThreeScaleToolbox::Command
+      def self.command
+        Cri::Command.define do
+          name        'policies'
+          usage       'policies <sub-command> [options]'
+          summary     'product super command'
+          description 'Policies commands'
+
+          run do |_opts, _args, cmd|
+            puts cmd.help
+          end
+        end
+      end
+      add_subcommand(ExportSubcommand)
+      add_subcommand(ImportSubcommand)
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/policies_command/export_command.rb
+++ b/lib/3scale_toolbox/commands/policies_command/export_command.rb
@@ -1,0 +1,98 @@
+module ThreeScaleToolbox
+  module Commands
+    module PoliciesCommand
+      class ExportSubcommand < Cri::CommandRunner
+        include ThreeScaleToolbox::Command
+
+        class JSONSerializer
+          def call(object)
+            JSON.pretty_generate(object)
+          end
+        end
+
+        class YAMLSerializer
+          def call(object)
+            YAML.dump(object)
+          end
+        end
+
+        class SerializerTransformer
+          def call(output_format)
+            raise unless %w[yaml json].include?(output_format)
+
+            case output_format
+            when 'yaml'
+              YAMLSerializer.new
+            when 'json'
+              JSONSerializer.new
+            end
+          end
+        end
+
+        def self.command
+          Cri::Command.define do
+            name        'export'
+            usage       'export [opts] <remote> <product>'
+            summary     'export product policy chain'
+            description 'export product policy chain'
+
+            option      :f, :file, 'Write to file instead of stdout', argument: :required
+            option      :o, :output, 'Output format. One of: json|yaml', argument: :required, transform: SerializerTransformer.new
+            param       :remote
+            param       :service_ref
+
+            runner ExportSubcommand
+          end
+        end
+
+        def run
+          select_output do |output|
+            output.write(serializer.call(product.policies))
+          end
+        end
+
+        private
+
+        def remote
+          @remote ||= threescale_client(arguments[:remote])
+        end
+
+        def product
+          @product ||= find_product
+        end
+
+        def service_ref
+          arguments[:service_ref]
+        end
+
+        def find_product
+          Entities::Service.find(remote: remote,
+                                 ref: service_ref).tap do |svc|
+            raise ThreeScaleToolbox::Error, "Product #{service_ref} does not exist" if svc.nil?
+          end
+        end
+
+        def file
+          options[:file]
+        end
+
+        def select_output
+          ios = if file
+                  File.open(file, 'w')
+                else
+                  $stdout
+                end
+          begin
+            yield(ios)
+          ensure
+            ios.close
+          end
+        end
+
+        def serializer
+          options.fetch(:output, YAMLSerializer.new)
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/policies_command/import_command.rb
+++ b/lib/3scale_toolbox/commands/policies_command/import_command.rb
@@ -1,0 +1,61 @@
+module ThreeScaleToolbox
+  module Commands
+    module PoliciesCommand
+      class ImportSubcommand < Cri::CommandRunner
+        include ThreeScaleToolbox::Command
+        include ThreeScaleToolbox::ResourceReader
+
+        def self.command
+          Cri::Command.define do
+            name        'import'
+            usage       'import [opts] <remote> <product>'
+            summary     'import product policy chain'
+            description 'import product policy chain'
+
+            option      :f, :file, 'Read from file', argument: :required
+            option      :u, :url, 'Read from url', argument: :required
+            param       :remote
+            param       :service_ref
+
+            runner ImportSubcommand
+          end
+        end
+
+        def run
+          res = product.update_policies('policies_config' => policies)
+          if res.is_a?(Hash) && (errors = res['errors'])
+            raise ThreeScaleToolbox::Error, "Product policies have not been imported. #{errors}"
+          end
+          if res.is_a?(Array) && (error_item = res.find { |i| i.key?('errors') })
+            raise ThreeScaleToolbox::Error, "Product policies have not been imported. #{error_item['errors']}"
+          end
+        end
+
+        private
+
+        def remote
+          @remote ||= threescale_client(arguments[:remote])
+        end
+
+        def service_ref
+          arguments[:service_ref]
+        end
+
+        def product
+          @product ||= find_product
+        end
+
+        def find_product
+          Entities::Service.find(remote: remote,
+                                 ref: service_ref).tap do |svc|
+            raise ThreeScaleToolbox::Error, "Product #{service_ref} does not exist" if svc.nil?
+          end
+        end
+
+        def policies
+          @policies ||= load_resource(options[:file] || options[:url] || '-')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands/policies_command/export_command_spec.rb
+++ b/spec/unit/commands/policies_command/export_command_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe ThreeScaleToolbox::Commands::PoliciesCommand::ExportSubcommand do
+  include_context :temp_dir
+
+  context '#run' do
+    let(:remote) { instance_double(ThreeScale::API::Client) }
+    let(:remote_name) { 'myremote' }
+    let(:service_ref) { 1 }
+    let(:arguments) { { remote: remote_name, service_ref: service_ref.to_s } }
+    let(:output_file) {}
+    let(:options) { { file: output_file } }
+    let(:policy1) do
+      {
+        'name' => 'apicast',
+        'version' => 'builtin',
+        'configuration' => {},
+        'enabled' => true
+      }
+    end
+    let(:policy2) do
+      {
+        'name' => 'content_caching',
+        'version' => 'builtin',
+        'configuration' => {},
+        'enabled' => true
+      }
+    end
+    let(:policy_chain) { [policy1, policy2] }
+    let(:svc_a_attrs) { { 'id' => service_ref } }
+
+    subject { described_class.new(options, arguments, nil) }
+
+    before :example do
+      expect(subject).to receive(:threescale_client).with(remote_name).and_return(remote)
+      expect(remote).to receive(:show_service).and_return(svc_a_attrs)
+      expect(remote).to receive(:show_policies).and_return(policy_chain)
+    end
+
+    context 'when file selected' do
+      let(:output_file) { tmp_dir.join('policies.yaml') }
+
+      it 'content is written to the file' do
+        subject.run
+        expect(output_file.read.size).to be_positive
+      end
+
+      it 'exports product policy chain' do
+        subject.run
+        exported_policies = YAML.safe_load(output_file.read)
+        expect(exported_policies).to include(policy1, policy2)
+      end
+    end
+  end
+end

--- a/spec/unit/commands/policies_command/import_command_spec.rb
+++ b/spec/unit/commands/policies_command/import_command_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe ThreeScaleToolbox::Commands::PoliciesCommand::ImportSubcommand do
+  include_context :temp_dir
+
+  context '#run' do
+    let(:remote) { instance_double(ThreeScale::API::Client) }
+    let(:remote_name) { 'myremote' }
+    let(:service_ref) { 1 }
+    let(:arguments) { { remote: remote_name, service_ref: service_ref.to_s } }
+    let(:input_file) {}
+    let(:options) { { file: input_file } }
+    let(:policy1) do
+      {
+        'name' => 'apicast',
+        'version' => 'builtin',
+        'configuration' => {},
+        'enabled' => true
+      }
+    end
+    let(:policy2) do
+      {
+        'name' => 'content_caching',
+        'version' => 'builtin',
+        'configuration' => {},
+        'enabled' => true
+      }
+    end
+    let(:policy_chain) { [policy1, policy2] }
+    let(:svc_a_attrs) { { 'id' => service_ref } }
+
+    subject { described_class.new(options, arguments, nil) }
+
+    before :example do
+      expect(subject).to receive(:threescale_client).with(remote_name).and_return(remote)
+      expect(remote).to receive(:show_service).and_return(svc_a_attrs)
+    end
+
+    context 'when file selected' do
+      let(:input_file) { tmp_dir.join('policies.yaml').tap { |policies_file| policies_file.write(policy_chain.to_yaml) } }
+
+      it 'imports product policy chain' do
+        expect(remote).to receive(:update_policies).with(service_ref, hash_including('policies_config' => policy_chain))
+
+        subject.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
* `3scale policies export` command to export one product's policy chain to yaml/json format
* `3scale policies import` command to import one product's policy chain from yaml/json format