### PR TITLE
Change base image: ruby:2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM centos/ruby-25-centos7:latest
+FROM ruby:2.7
 MAINTAINER Eguzki Astiz Lezaun <eastizle@redhat.com>
 
-USER root
-WORKDIR /opt/app-root/src
+WORKDIR /usr/src/app
 COPY . .
-RUN /bin/bash -l -c "gem build 3scale_toolbox.gemspec"
-RUN /bin/bash -l -c "gem install 3scale_toolbox-*.gem --no-document"
+RUN gem build 3scale_toolbox.gemspec
+RUN gem install 3scale_toolbox-*.gem --no-document
+RUN adduser  --home /home/toolboxuser toolboxuser
+WORKDIR /home/toolboxuser
 
 # clean up
-RUN rm -rf /opt/app-root/src/*
+RUN rm -rf /usr/src/app
 
 # Drop privileges
-USER default
+USER toolboxuser


### PR DESCRIPTION
Currently, `centos/ruby-25-centos7:latest` base image with tag `centos/ruby-25-centos7@sha256:71a4818652959d2c03e98b42ad74571426fb5ccab3f93448ba1dd2524a6ad0ef`  breaks the build:

```
$ docker run --rm -ti quay.io/redhat/3scale-toolbox:master 3scale help
/usr/bin/container-entrypoint: line 2: exec: 3scale: not found
```

