### PR TITLE
Added optional argument to openapi import command to allow setting oidc issuer type

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -62,7 +62,7 @@ OPTIONS
        --default-credentials-userkey=<value>      Default credentials policy
                                                   userkey
        --oidc-issuer-endpoint=<value>             OIDC Issuer Endpoint
-       --oidc-issuer-type[=<value>]               OIDC Issuer Type (rest,
+       --oidc-issuer-type=<value>                 OIDC Issuer Type (rest,
                                                   keycloak)
        --override-private-base-url=<value>        Custom private base URL
        --override-private-basepath=<value>        Override the basepath for

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -62,6 +62,8 @@ OPTIONS
        --default-credentials-userkey=<value>      Default credentials policy
                                                   userkey
        --oidc-issuer-endpoint=<value>             OIDC Issuer Endpoint
+       --oidc-issuer-type[=<value>]               OIDC Issuer Type (rest,
+                                                  keycloak)
        --override-private-base-url=<value>        Custom private base URL
        --override-private-basepath=<value>        Override the basepath for
                                                   the private URLs

--- a/lib/3scale_toolbox/commands/import_command/issuer_type_transformer.rb
+++ b/lib/3scale_toolbox/commands/import_command/issuer_type_transformer.rb
@@ -1,0 +1,16 @@
+module ThreeScaleToolbox
+  module Commands
+    module ImportCommand
+      module OpenAPI
+        # Helper class to validate values for the oidc-issuer-type argument of the import openapi command
+        class IssuerTypeTransformer
+          def call(issuer_type)
+            raise unless %w[rest keycloak].include?(issuer_type)
+
+            issuer_type
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -9,6 +9,7 @@ require '3scale_toolbox/commands/import_command/openapi/create_activedocs_step'
 require '3scale_toolbox/commands/import_command/openapi/update_service_proxy_step'
 require '3scale_toolbox/commands/import_command/openapi/update_service_oidc_conf_step'
 require '3scale_toolbox/commands/import_command/openapi/update_policies_step'
+require '3scale_toolbox/commands/import_command/issuer_type_transformer'
 
 module ThreeScaleToolbox
   module Commands
@@ -30,7 +31,7 @@ module ThreeScaleToolbox
               flag    nil, 'activedocs-hidden', 'Create ActiveDocs in hidden state'
               flag    nil, 'skip-openapi-validation', 'Skip OpenAPI schema validation'
               flag    nil, 'prefix-matching', 'Use prefix matching instead of strict matching on mapping rules derived from openapi operations'
-              option  nil, 'oidc-issuer-type', 'OIDC Issuer Type (rest, keycloak)', argument: :optional
+              option  nil, 'oidc-issuer-type', 'OIDC Issuer Type (rest, keycloak)', argument: :required, transform: IssuerTypeTransformer.new            
               option  nil, 'oidc-issuer-endpoint', 'OIDC Issuer Endpoint', argument: :required
               option  nil, 'default-credentials-userkey', 'Default credentials policy userkey', argument: :required
               option  nil, 'override-private-basepath', 'Override the basepath for the private URLs', argument: :required

--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -30,6 +30,7 @@ module ThreeScaleToolbox
               flag    nil, 'activedocs-hidden', 'Create ActiveDocs in hidden state'
               flag    nil, 'skip-openapi-validation', 'Skip OpenAPI schema validation'
               flag    nil, 'prefix-matching', 'Use prefix matching instead of strict matching on mapping rules derived from openapi operations'
+              option  nil, 'oidc-issuer-type', 'OIDC Issuer Type (rest, keycloak)', argument: :optional
               option  nil, 'oidc-issuer-endpoint', 'OIDC Issuer Endpoint', argument: :required
               option  nil, 'default-credentials-userkey', 'Default credentials policy userkey', argument: :required
               option  nil, 'override-private-basepath', 'Override the basepath for the private URLs', argument: :required
@@ -77,6 +78,7 @@ module ThreeScaleToolbox
               threescale_client: threescale_client(fetch_required_option(:destination)),
               target_system_name: options[:target_system_name],
               activedocs_published: !options[:'activedocs-hidden'],
+              oidc_issuer_type: options[:'oidc-issuer-type'],
               oidc_issuer_endpoint: options[:'oidc-issuer-endpoint'],
               default_credentials_userkey: options[:'default-credentials-userkey'],
               skip_openapi_validation: options[:'skip-openapi-validation'],

--- a/lib/3scale_toolbox/commands/import_command/openapi/step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/step.rb
@@ -57,6 +57,10 @@ module ThreeScaleToolbox
             context[:api_spec_resource]
           end
 
+          def oidc_issuer_type
+            context[:oidc_issuer_type]
+          end
+
           def oidc_issuer_endpoint
             context[:oidc_issuer_endpoint]
           end

--- a/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/update_service_proxy_step.rb
@@ -52,6 +52,7 @@ module ThreeScaleToolbox
             case (type = api_spec.security[:type])
             when 'oauth2'
               settings[:credentials_location] = 'headers'
+              settings[:oidc_issuer_type] = oidc_issuer_type unless oidc_issuer_type.nil?
               settings[:oidc_issuer_endpoint] = oidc_issuer_endpoint unless oidc_issuer_endpoint.nil?
             when 'apiKey'
               settings[:credentials_location] = credentials_location

--- a/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
   let(:staging_public_base_url) { nil }
   let(:override_private_base_url) { nil }
   let(:oidc_issuer_endpoint) { 'https://sso.example.com' }
+  let(:oidc_issuer_type) { nil }
   let(:backend_api_secret_token) { nil }
   let(:backend_api_host_header) { nil }
 
@@ -18,6 +19,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
       target: service,
       api_spec: api_spec,
       oidc_issuer_endpoint: oidc_issuer_endpoint,
+      oidc_issuer_type: oidc_issuer_type,
       production_public_base_url: production_public_base_url,
       staging_public_base_url: staging_public_base_url,
       override_private_base_url: override_private_base_url,
@@ -148,6 +150,32 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
         expect(service).to receive(:update_proxy)
           .with(hash_including(
                   credentials_location: 'headers',
+                  oidc_issuer_endpoint: oidc_issuer_endpoint
+                )).and_return({})
+        subject
+      end
+    end
+
+    context 'oidc issuer type (default) set' do
+      let(:security) { { id: 'oidc', type: 'oauth2', flow: :implicit_flow_enabled } }
+
+      it 'updates proxy with correct default oidc type' do
+        expect(service).to receive(:update_proxy)
+          .with(hash_including(
+                  oidc_issuer_endpoint: oidc_issuer_endpoint
+                )).and_return({})
+        subject
+      end
+    end
+
+    context 'correct oidc issuer type set' do
+      let(:security) { { id: 'oidc', type: 'oauth2', flow: :implicit_flow_enabled } }
+      let(:oidc_issuer_type) {'rest'}
+      
+      it 'updates proxy with correct oidc type' do
+        expect(service).to receive(:update_proxy)
+          .with(hash_including(
+                  oidc_issuer_type: oidc_issuer_type,
                   oidc_issuer_endpoint: oidc_issuer_endpoint
                 )).and_return({})
         subject

--- a/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
+++ b/spec/unit/commands/import_command/openapi/update_service_proxy_spec.rb
@@ -161,8 +161,8 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::UpdateServic
 
       it 'updates proxy with correct default oidc type' do
         expect(service).to receive(:update_proxy)
-          .with(hash_including(
-                  oidc_issuer_endpoint: oidc_issuer_endpoint
+          .with(hash_excluding(
+                  :oidc_issuer_type
                 )).and_return({})
         subject
       end


### PR DESCRIPTION
Added optional parameter to openapi import spec to allow setting oidc issuer type.
Updated documentation to reflect new argument in openapi import command.
Added unit tests to verify new argument is working correctly and is compatible with earlier versions.

There are no license changes in this commit.