### PR TITLE
new command: 3scale proxy-config deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
    * Create, Apply, List, Delete [Method](docs/method.md)
    * Create, Apply, List, Show, Delete [Service](docs/service.md)
    * Create, Apply, List, Delete [ActiveDocs](docs/activedocs.md)
-   * List, Show, Promote, Export [Proxy Configuration](docs/proxy-config.md)
+   * List, Show, Promote, Export, Deploy [Proxy Configuration](docs/proxy-config.md)
    * [Copy Policy Registry](docs/copy-policy-registry.md)
    * Create, Apply, List, Show, Delete, Suspend, Resume [Applications](docs/applications.md)
    * [Export/Import Product Policy Chain](docs/export-import-policy-chain.md)

--- a/docs/proxy-config.md
+++ b/docs/proxy-config.md
@@ -4,6 +4,7 @@
 * [Show Proxy Configuration](#show)
 * [Promote Proxy Configuration](#promote)
 * [Export Proxy Configuration](#export)
+* [Deploy Proxy Configuration](#deploy)
 
 ### List
 
@@ -103,5 +104,22 @@ DESCRIPTION
 OPTIONS
        --environment=<value>      Gateway environment. Must be 'sandbox' or
                                   'production' (default: sandbox)
+    -o --output=<value>           Output format. One of: json|yaml
+```
+
+### Deploy
+
+```shell
+NAME
+    deploy - Promotes the APIcast configuration to the Staging Environment
+
+USAGE
+    3scale proxy-config deploy <remote> <service>
+
+DESCRIPTION
+    Promotes the APIcast configuration to the Staging Environment (Production
+    Environment in case of Service Mesh).
+
+OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
 ```

--- a/lib/3scale_toolbox/commands/proxy_config_command.rb
+++ b/lib/3scale_toolbox/commands/proxy_config_command.rb
@@ -5,6 +5,7 @@ require '3scale_toolbox/commands/proxy_config_command/list_command'
 require '3scale_toolbox/commands/proxy_config_command/show_command'
 require '3scale_toolbox/commands/proxy_config_command/promote_command'
 require '3scale_toolbox/commands/proxy_config_command/export_command'
+require '3scale_toolbox/commands/proxy_config_command/deploy_command'
 
 module ThreeScaleToolbox
   module Commands
@@ -28,6 +29,7 @@ module ThreeScaleToolbox
       add_subcommand(Show::ShowSubcommand)
       add_subcommand(Promote::PromoteSubcommand)
       add_subcommand(Export::ExportSubcommand)
+      add_subcommand(DeploySubcommand)
     end
   end
 end

--- a/lib/3scale_toolbox/commands/proxy_config_command/deploy_command.rb
+++ b/lib/3scale_toolbox/commands/proxy_config_command/deploy_command.rb
@@ -1,0 +1,54 @@
+module ThreeScaleToolbox
+  module Commands
+    module ProxyConfigCommand
+      class DeploySubcommand < Cri::CommandRunner
+        include ThreeScaleToolbox::Command
+
+        def self.command
+          Cri::Command.define do
+            name        'deploy'
+            usage       'deploy <remote> <service>'
+            summary     'Promotes the APIcast configuration to the Staging Environment'
+            description 'Promotes the APIcast configuration to the Staging Environment (Production Environment in case of Service Mesh).'
+
+            param :remote
+            param :service_ref
+
+            ThreeScaleToolbox::CLI.output_flag(self)
+
+            runner DeploySubcommand
+          end
+        end
+
+        def run
+          printer.print_record service.proxy_deploy
+        end
+
+        private
+
+        def remote
+          @remote ||= threescale_client(arguments[:remote])
+        end
+
+        def service_ref
+          arguments[:service_ref]
+        end
+
+        def find_service
+          Entities::Service.find(remote: remote,
+                                 ref: service_ref).tap do |svc|
+            raise ThreeScaleToolbox::Error, "Service #{service_ref} does not exist" if svc.nil?
+          end
+        end
+
+        def service
+          @service ||= find_service
+        end
+
+        def printer
+          options.fetch(:output, CLI::JsonPrinter.new)
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale_toolbox/entities/service.rb
+++ b/lib/3scale_toolbox/entities/service.rb
@@ -288,6 +288,15 @@ module ThreeScaleToolbox
         end
       end
 
+      def proxy_deploy
+        proxy_attrs = remote.proxy_deploy id
+        if proxy_attrs.respond_to?(:has_key?) && (errors = proxy_attrs['errors'])
+          raise ThreeScaleToolbox::ThreeScaleApiError.new('Proxy configuration not deployed', errors)
+        end
+
+        proxy_attrs
+      end
+
       def ==(other)
         remote.http_client.endpoint == other.remote.http_client.endpoint && id == other.id
       end

--- a/spec/unit/commands/proxy_config_command/deploy_command_spec.rb
+++ b/spec/unit/commands/proxy_config_command/deploy_command_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe ThreeScaleToolbox::Commands::ProxyConfigCommand::DeploySubcommand do
+  context '#run' do
+    let(:remote) { instance_double(ThreeScale::API::Client) }
+    let(:remote_name) { 'myremote' }
+    let(:service_ref) { 'myservice' }
+    let(:service_id) { 1 }
+    let(:arguments) { {remote: remote_name, service_ref: service_ref} }
+    let(:options) { {} }
+    let(:proxy_attrs) { { 'id' => '1' } }
+    let(:pretty_printed_proxy) { JSON.pretty_generate(proxy_attrs) + "\n" }
+    let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
+    let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
+
+    subject { described_class.new(options, arguments, nil) }
+
+    before :example do
+      expect(subject).to receive(:threescale_client).with(remote_name).and_return(remote)
+      expect(service_class).to receive(:find).with(remote: remote, ref: service_ref).and_return(service)
+      expect(service).to receive(:proxy_deploy).and_return(proxy_attrs)
+    end
+
+    it 'exports proxy config for all products' do
+      expect { subject.run }.to output(pretty_printed_proxy).to_stdout
+    end
+  end
+end

--- a/spec/unit/entities/service_spec.rb
+++ b/spec/unit/entities/service_spec.rb
@@ -614,5 +614,24 @@ RSpec.describe ThreeScaleToolbox::Entities::Service do
         end
       end
     end
+
+    context '#proxy_deploy' do
+      let(:proxy_attrs) do
+        {
+          'service_id' => id,
+          'endpoint' => 'https://example.com:443',
+        }
+      end
+
+      it 'calls proxy_deploy method' do
+        expect(remote).to receive(:proxy_deploy).with(id).and_return(proxy_attrs)
+        expect(subject.proxy_deploy).to eq(proxy_attrs)
+      end
+
+      it 'raises error on remote error' do
+        expect(remote).to receive(:proxy_deploy).with(id).and_return(common_error_response)
+        expect { subject.proxy_deploy }.to raise_error(ThreeScaleToolbox::Error)
+      end
+    end
   end
 end


### PR DESCRIPTION
Command to promote the APIcast configuration to the Staging Environment 

Only supported in 3scale release >= 2.7

Requires: https://github.com/3scale/3scale-api-ruby/pull/94

Jira Issue: https://issues.redhat.com/browse/THREESCALE-6620