### PR TITLE
Fix proxy config integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ workflows:
           type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
           # On approval of the `hold` job, any successive job that requires the `hold` job will run.
       - integration_tests:
-          context: supertestaccount
+          context: autotestaccount
           requires:
             - manual_approval
   nightly:
@@ -158,5 +158,5 @@ workflows:
                 - master
     jobs:
       - integration_tests:
-          context: supertestaccount
+          context: autotestaccount
       - docker_container_help_test

--- a/3scale_toolbox.gemspec
+++ b/3scale_toolbox.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.4'
   spec.required_ruby_version = '>= 2.5'
 
-  spec.add_dependency '3scale-api', '~> 1.3'
+  spec.add_dependency '3scale-api', '~> 1.4'
   spec.add_dependency 'cri', '~> 2.15'
   spec.add_dependency 'json-schema', '~> 2.8'
   spec.add_dependency 'oas_parser', '~> 0.20'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     3scale_toolbox (0.17.1)
-      3scale-api (~> 1.3)
+      3scale-api (~> 1.4)
       cri (~> 2.15)
       json-schema (~> 2.8)
       oas_parser (~> 0.20)
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    3scale-api (1.3.0)
+    3scale-api (1.4.0)
     activesupport (6.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)

--- a/lib/3scale_toolbox/entities/application_plan.rb
+++ b/lib/3scale_toolbox/entities/application_plan.rb
@@ -14,7 +14,7 @@ module ThreeScaleToolbox
         # ref can be system_name or service_id
         def find(service:, ref:)
           new(id: ref, service: service).tap(&:attrs)
-        rescue ThreeScale::API::HttpClient::NotFoundError
+        rescue ThreeScaleToolbox::InvalidIdError, ThreeScale::API::HttpClient::NotFoundError
           find_by_system_name(service: service, system_name: ref)
         end
 
@@ -206,6 +206,8 @@ module ThreeScaleToolbox
       private
 
       def read_plan_attrs
+        raise ThreeScaleToolbox::InvalidIdError if id.zero?
+
         plan_attrs = remote.show_application_plan service.id, id
         if (errors = plan_attrs['errors'])
           raise ThreeScaleToolbox::ThreeScaleApiError.new('Application plan not read', errors)

--- a/spec/integration/commands/proxy_config_command/list_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/list_command_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'ProxyConfig List command' do
 
       svc
   end
+  let(:hits_id) { service.hits.fetch('id') }
 
   context "With multiple existing Proxy Configurations" do
     before :example do
@@ -32,10 +33,11 @@ RSpec.describe 'ProxyConfig List command' do
 
       pc.promote(to: "production")
 
-      ThreeScaleToolbox::Entities::Metric.create(service: service, attrs: { friendly_name: "mymetric_#{random_lowercase_name}",
-                                                                            unit: "1",
-                                                                          }
-                                                )
+      service.create_mapping_rule('pattern' => "/pets/#{random_lowercase_name}$",
+                                'http_method' => 'GET',
+                                'delta' => 1,
+                                'metric_id' => hits_id
+                               )
 
       api3scale_client.proxy_deploy service.id
 
@@ -44,10 +46,11 @@ RSpec.describe 'ProxyConfig List command' do
 
       pc.promote(to: "production")
 
-      ThreeScaleToolbox::Entities::Metric.create(service: service, attrs: { friendly_name: "mymetric_#{random_lowercase_name}",
-                                                                            unit: "1",
-                                                                          }
-                                                )
+      service.create_mapping_rule('pattern' => "/pets/#{random_lowercase_name}$",
+                                'http_method' => 'GET',
+                                'delta' => 1,
+                                'metric_id' => hits_id
+                               )
       api3scale_client.proxy_deploy service.id
     end
 

--- a/spec/integration/commands/proxy_config_command/list_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/list_command_spec.rb
@@ -9,40 +9,56 @@ RSpec.describe 'ProxyConfig List command' do
   let(:service_ref) { "svc_#{random_lowercase_name}" }
   let(:environment_sandbox) { "sandbox" }
   let(:environment_prod) { "production" }
-  
+  let(:service) do
+      svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
+      backend = ThreeScaleToolbox::Entities::Backend::create(remote: api3scale_client,
+                                                             attrs: { 'name' => "mybackend_#{random_lowercase_name}",
+                                                                      'private_endpoint' => 'https://example.com'
+                                                                    }
+                                                            )
+      ThreeScaleToolbox::Entities::BackendUsage::create(product: svc, attrs: { 'backend_api_id' => backend.id,
+                                                                               'path' => '/v3'
+                                                                              }
+                                                       )
+      api3scale_client.proxy_deploy svc.id
+
+      svc
+  end
+
   context "With multiple existing Proxy Configurations" do
     before :example do
-      svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
+      pc = ThreeScaleToolbox::Entities::ProxyConfig::find(service: service, environment: environment_sandbox, version: 1)
+      expect(pc).not_to be_nil
 
-      # Service needs backend api. Otherwise proxy config will not be promoted to sandbox
-      svc.update_proxy('api_backend' => 'https://example.com')
-      pc_sandbox_1 = nil
-      Helpers.wait do
-        pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)
-        !pc_sandbox_1.nil? 
-      end
+      pc.promote(to: "production")
 
-      pc_sandbox_1.promote(to: "production")
+      ThreeScaleToolbox::Entities::Metric.create(service: service, attrs: { friendly_name: "mymetric_#{random_lowercase_name}",
+                                                                            unit: "1",
+                                                                          }
+                                                )
 
-      svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage2" })
-      pc_sandbox_2 = nil
-      Helpers.wait do
-        pc_sandbox_2 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 2)
-        !pc_sandbox_2.nil? 
-      end
-      pc_sandbox_2.promote(to: "production")
+      api3scale_client.proxy_deploy service.id
 
-      svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage3" })
+      pc = ThreeScaleToolbox::Entities::ProxyConfig::find(service: service, environment: environment_sandbox, version: 2)
+      expect(pc).not_to be_nil
+
+      pc.promote(to: "production")
+
+      ThreeScaleToolbox::Entities::Metric.create(service: service, attrs: { friendly_name: "mymetric_#{random_lowercase_name}",
+                                                                            unit: "1",
+                                                                          }
+                                                )
+      api3scale_client.proxy_deploy service.id
     end
 
     context "listing sandbox Proxy configurations" do
-      let (:command_line_str) { "proxy-config list #{remote} #{service_ref} #{environment_sandbox}" }
+      let (:command_line_str) { "proxy-config list #{remote} #{service.id} #{environment_sandbox}" }
 
       it "lists proxy_config sandbox version 1" do
         expect { subject }.to output(/.*1.*#{environment_sandbox}.*/).to_stdout
         expect(subject).to eq(0)
       end
-  
+
       it "lists proxy_config sandbox version 2" do
         expect { subject }.to output(/.*2.*#{environment_sandbox}.*/).to_stdout
         expect(subject).to eq(0)
@@ -55,13 +71,13 @@ RSpec.describe 'ProxyConfig List command' do
     end
 
     context "listing production Proxy configurations" do
-      let (:command_line_str) { "proxy-config list #{remote} #{service_ref} #{environment_prod}" }
+      let (:command_line_str) { "proxy-config list #{remote} #{service.id} #{environment_prod}" }
 
       it "lists proxy_config production version 1" do
         expect { subject }.to output(/.*1.*#{environment_prod}.*/).to_stdout
         expect(subject).to eq(0)
       end
-  
+
       it "lists proxy_config production version 2" do
         expect { subject }.to output(/.*2.*#{environment_prod}.*/).to_stdout
         expect(subject).to eq(0)

--- a/spec/integration/commands/proxy_config_command/show_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/show_command_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'ProxyConfig Show command' do
 
       svc
     end
+    let(:hits_id) { service.hits.fetch('id') }
 
     before :example do
       pc = ThreeScaleToolbox::Entities::ProxyConfig::find(service: service, environment: environment_sandbox, version: 1)
@@ -33,10 +34,11 @@ RSpec.describe 'ProxyConfig Show command' do
 
       pc.promote(to: "production")
 
-      ThreeScaleToolbox::Entities::Metric.create(service: service, attrs: { friendly_name: "mymetric_#{random_lowercase_name}",
-                                                                            unit: "1",
-                                                                          }
-                                                )
+      service.create_mapping_rule('pattern' => "/pets/#{random_lowercase_name}$",
+                                'http_method' => 'GET',
+                                'delta' => 1,
+                                'metric_id' => hits_id
+                               )
       api3scale_client.proxy_deploy service.id
 
       pc = ThreeScaleToolbox::Entities::ProxyConfig::find(service: service, environment: environment_sandbox, version: 2)
@@ -44,10 +46,11 @@ RSpec.describe 'ProxyConfig Show command' do
 
       pc.promote(to: "production")
 
-      ThreeScaleToolbox::Entities::Metric.create(service: service, attrs: { friendly_name: "mymetric_#{random_lowercase_name}",
-                                                                            unit: "1",
-                                                                          }
-                                                )
+      service.create_mapping_rule('pattern' => "/pets/#{random_lowercase_name}$",
+                                'http_method' => 'GET',
+                                'delta' => 1,
+                                'metric_id' => hits_id
+                               )
       api3scale_client.proxy_deploy service.id
     end
 

--- a/spec/integration/commands/proxy_config_command/show_command_spec.rb
+++ b/spec/integration/commands/proxy_config_command/show_command_spec.rb
@@ -11,26 +11,44 @@ RSpec.describe 'ProxyConfig Show command' do
   let(:environment_prod) { "production" }
 
   context "With the specified service existing" do
-    before :example do
+    let(:service) do
       svc = ThreeScaleToolbox::Entities::Service::create(remote: api3scale_client, service_params: {"name" => service_ref})
-      # Service needs backend api. Otherwise proxy config will not be promoted to sandbox
-      svc.update_proxy('api_backend' => 'https://example.com')
-      pc_sandbox_1 = nil
-      Helpers.wait do
-        pc_sandbox_1 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 1)
-        !pc_sandbox_1.nil?
-      end
-      pc_sandbox_1.promote(to: "production")
+      backend = ThreeScaleToolbox::Entities::Backend::create(remote: api3scale_client,
+                                                             attrs: { 'name' => "mybackend_#{random_lowercase_name}",
+                                                                      'private_endpoint' => 'https://example.com'
+                                                                    }
+                                                            )
+      ThreeScaleToolbox::Entities::BackendUsage::create(product: svc, attrs: { 'backend_api_id' => backend.id,
+                                                                               'path' => '/v3'
+                                                                              }
+                                                       )
+      api3scale_client.proxy_deploy svc.id
 
-      svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage2" })
-      pc_sandbox_2 = nil
-      Helpers.wait do
-        pc_sandbox_2 = ThreeScaleToolbox::Entities::ProxyConfig::find(service: svc, environment: environment_sandbox, version: 2)
-        !pc_sandbox_2.nil?
-      end
-      pc_sandbox_2.promote(to: "production")
+      svc
+    end
 
-      svc.update_proxy({ "error_auth_failed" => "exampleautherrormessage3" })
+    before :example do
+      pc = ThreeScaleToolbox::Entities::ProxyConfig::find(service: service, environment: environment_sandbox, version: 1)
+      expect(pc).not_to be_nil
+
+      pc.promote(to: "production")
+
+      ThreeScaleToolbox::Entities::Metric.create(service: service, attrs: { friendly_name: "mymetric_#{random_lowercase_name}",
+                                                                            unit: "1",
+                                                                          }
+                                                )
+      api3scale_client.proxy_deploy service.id
+
+      pc = ThreeScaleToolbox::Entities::ProxyConfig::find(service: service, environment: environment_sandbox, version: 2)
+      expect(pc).not_to be_nil
+
+      pc.promote(to: "production")
+
+      ThreeScaleToolbox::Entities::Metric.create(service: service, attrs: { friendly_name: "mymetric_#{random_lowercase_name}",
+                                                                            unit: "1",
+                                                                          }
+                                                )
+      api3scale_client.proxy_deploy service.id
     end
 
     context "and with environment set to sandbox" do
@@ -38,11 +56,12 @@ RSpec.describe 'ProxyConfig Show command' do
 
       context "without specifying a config-version" do
         let(:expected_config_version) { 3 }
-        let(:command_line_str) { "proxy-config show #{remote} #{service_ref} #{environment}" }
+        let(:command_line_str) { "proxy-config show #{remote} #{service.id} #{environment}" }
         it "returns the latest available version" do
           expect { subject }.to output(/"version": #{expected_config_version}/).to_stdout
           expect(subject).to eq(0)
         end
+
         it "returns the specified environment" do
           expect { subject }.to output(/"environment": "#{environment}"/).to_stdout
           expect(subject).to eq(0)
@@ -52,7 +71,7 @@ RSpec.describe 'ProxyConfig Show command' do
       context "specifying a config-version" do
         let(:config_version) { 2 }
         let(:expected_config_version) { config_version }
-        let(:command_line_str) { "proxy-config show #{remote} #{service_ref} #{environment} --config-version #{config_version}" }
+        let(:command_line_str) { "proxy-config show #{remote} #{service.id} #{environment} --config-version #{config_version}" }
 
         it "returns the specified version" do
           expect { subject }.to output(/"version": #{expected_config_version}/).to_stdout
@@ -70,7 +89,7 @@ RSpec.describe 'ProxyConfig Show command' do
 
       context "without specifying a config-version" do
         let(:expected_config_version) { 2 }
-        let(:command_line_str) { "proxy-config show #{remote} #{service_ref} #{environment}" }
+        let(:command_line_str) { "proxy-config show #{remote} #{service.id} #{environment}" }
 
         it "returns the latest available version" do
           expect { subject }.to output(/"version": #{expected_config_version}/).to_stdout
@@ -85,7 +104,7 @@ RSpec.describe 'ProxyConfig Show command' do
       context "specifying a config-version" do
         let(:config_version) { 1 }
         let(:expected_config_version) { config_version }
-        let(:command_line_str) { "proxy-config show #{remote} #{service_ref} #{environment} --config-version #{config_version}" }
+        let(:command_line_str) { "proxy-config show #{remote} #{service.id} #{environment} --config-version #{config_version}" }
 
         it "returns the specified version" do
           expect { subject }.to output(/"version": #{expected_config_version}/).to_stdout

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -46,7 +46,7 @@ RSpec.shared_context :plugin do
 end
 
 RSpec.shared_context :allow_net_connect do
-  around :context do |example|
+  around :example do |example|
     WebMock.allow_net_connect!
     example.run
     WebMock.disable_net_connect!

--- a/spec/unit/entities/application_plan_spec.rb
+++ b/spec/unit/entities/application_plan_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe ThreeScaleToolbox::Entities::ApplicationPlan do
       let(:plans) { [plan_attrs] }
 
       before :example do
-        expect(remote).to receive(:show_application_plan).and_raise(ThreeScale::API::HttpClient::NotFoundError.new(nil))
         expect(service).to receive(:plans).and_return(plans)
       end
 
@@ -105,7 +104,6 @@ RSpec.describe ThreeScaleToolbox::Entities::ApplicationPlan do
       let(:plans) { [] }
 
       before :example do
-        expect(remote).to receive(:show_application_plan).and_raise(ThreeScale::API::HttpClient::NotFoundError.new(nil))
         expect(service).to receive(:plans).and_return(plans)
       end
 


### PR DESCRIPTION
Proxy config integration tests are failing 80% of the runs. 

The main reason: Sometimes (more often than expected) `update_proxy` operation does not deploy proxy configuration to "staging" or sandbox. It is not eventually deployed, it is never deployed. Used `proxy deploy` operation to actually deploy proxy configuration to staging.