### PR TITLE
import/openapi/create_method_step: fix nomethoderror when importing twice

### DIFF
--- a/lib/3scale_toolbox/commands/import_command/openapi/create_method_step.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi/create_method_step.rb
@@ -12,7 +12,7 @@ module ThreeScaleToolbox
             end
 
             existing_operations.each do |op|
-              method_attrs = methods_index.fetch(op.method['system_name'])
+              method_attrs = methods_index.fetch(op.method['system_name']).attrs
               method = Entities::Method.new(id: method_attrs.fetch('id'), service: service)
               method.update(op.method)
               op.set(:metric_id, method.id)
@@ -23,7 +23,7 @@ module ThreeScaleToolbox
 
           def methods_index
             @methods_index ||= service.methods.each_with_object({}) do |method, acc|
-              acc[method['system_name']] = method
+              acc[method.system_name] = method
             end
           end
 

--- a/spec/unit/commands/import_command/openapi/create_methods_step_spec.rb
+++ b/spec/unit/commands/import_command/openapi/create_methods_step_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMethod
                                                 .and_return(method_1)
         expect(method_0).to receive(:id).and_return(0)
         expect(method_1).to receive(:id).and_return(1)
+        expect(service).to receive(:methods).and_return([])
       end
 
       it 'methods created' do
@@ -36,7 +37,11 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::CreateMethod
 
     context 'when methods exist' do
       before :example do
-        expect(service).to receive(:methods).and_return([method_0_attrs, method_1_attrs])
+        expect(service).to receive(:methods).and_return([method_0, method_1])
+        allow(method_0).to receive(:system_name).and_return(method_0_attrs['system_name'])
+        allow(method_1).to receive(:system_name).and_return(method_1_attrs['system_name'])
+        allow(method_0).to receive(:attrs).and_return(method_0_attrs)
+        allow(method_1).to receive(:attrs).and_return(method_1_attrs)
         expect(method_class).to receive(:new).with(id: 0, service: service)
                                              .and_return(method_0)
         expect(method_class).to receive(:new).with(id: 1, service: service)


### PR DESCRIPTION
When the command `import openapi` was called twice with the same OpenAPI file spec toolbox returned a `NoMethodError` error, with the import execution failing.

The returned data types were incorrect and used methods could not be
found. This fixes it.

Related to issue https://github.com/3scale/3scale_toolbox/issues/291