### PR TITLE
enable unittest for tag builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,16 @@
 version: 2.1
 
+##################################### YAML ANCHORS  ############################################
+
+tag-trigger: &tag-trigger
+  tags:
+    only: /^v.*/
+
+only-master-filter: &only-master-filter
+  filters:
+    branches:
+      only: master
+
 commands:
   setup-bundler:
     steps:
@@ -148,11 +159,21 @@ workflows:
   version: 2
   basic_tests:
     jobs:
-      - ruby-255-unittest
-      - ruby-262-unittest
-      - ruby-270-unittest
-      - license_check
-      - help_test
+      - ruby-255-unittest:
+          filters:
+            <<: *tag-trigger
+      - ruby-262-unittest:
+          filters:
+            <<: *tag-trigger
+      - ruby-270-unittest:
+          filters:
+            <<: *tag-trigger
+      - license_check:
+          filters:
+            <<: *tag-trigger
+      - help_test:
+          filters:
+            <<: *tag-trigger
       - push-rubygems:
           requires:
             - ruby-255-unittest
@@ -161,8 +182,7 @@ workflows:
             - license_check
             - help_test
           filters:
-            tags:
-              only: /^v.*/
+            <<: *tag-trigger
             branches:
               ignore: /.*/
 
@@ -179,10 +199,7 @@ workflows:
     triggers:
       - schedule:
           cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+          <<: *only-master-filter
     jobs:
       - integration_tests:
           context: autotestaccount


### PR DESCRIPTION
CircleCI does not run workflows for tags unless you explicitly specify tag filters.