### PR TITLE
bundler using v2.2.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
             sudo gem uninstall bundler
             sudo rm /usr/local/bin/bundle || true
             sudo rm /usr/local/bin/bundler || true
-            sudo gem install bundler
+            sudo gem install bundler --version 2.2.21
 
   install_dependencies:
     steps:
@@ -58,8 +58,6 @@ jobs:
   ruby-262-unittest:
     docker:
       - image: circleci/ruby:2.6.2
-        environment:
-          BUNDLER_VERSION: 2.1.4
     working_directory: ~/repo
     steps:
       - checkout
@@ -72,13 +70,12 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
+      - setup-bundler
       - unittests
 
   license_check:
     docker:
-      - image: circleci/ruby:2.5.5
-        environment:
-          BUNDLER_VERSION: 2.1.4
+      - image: circleci/ruby:2.6.2
     working_directory: ~/repo
     steps:
       - checkout
@@ -91,9 +88,7 @@ jobs:
 
   help_test:
     docker:
-      - image: circleci/ruby:2.5.5
-        environment:
-          BUNDLER_VERSION: 2.1.4
+      - image: circleci/ruby:2.6.2
     working_directory: ~/repo
     steps:
       - checkout
@@ -106,9 +101,7 @@ jobs:
 
   integration_tests:
     docker:
-      - image: circleci/ruby:2.5.5
-        environment:
-          BUNDLER_VERSION: 2.1.4
+      - image: circleci/ruby:2.6.2
     working_directory: ~/repo
     steps:
       - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ os: linux
 before_install:
   - .travis/setup_${TRAVIS_CPU_ARCH}_env.sh
 
+install:
+  - .travis/install_${TRAVIS_CPU_ARCH}_env.sh
+
 script:
   - .travis/build_${TRAVIS_CPU_ARCH}.sh

--- a/.travis/build_ppc64le.sh
+++ b/.travis/build_ppc64le.sh
@@ -2,9 +2,6 @@
 
 set -ev
 
-bundle config set --local path 'vendor/bundle'
-bundle install --jobs=3 --retry=3
-
 # unit tests
 bundle exec rake spec:unit
 

--- a/.travis/install_ppc64le_env.sh
+++ b/.travis/install_ppc64le_env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ev
+
+bundle config --local set path 'vendor/bundle'
+bundle lock --add-platform powerpc64le-linux
+bundle install --jobs=3 --retry=3

--- a/.travis/setup_ppc64le_env.sh
+++ b/.travis/setup_ppc64le_env.sh
@@ -2,4 +2,4 @@
 
 set -ev
 
-sudo apt-get update
+gem install bundler --version 2.2.21

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     3scale-api (1.4.0)
-    activesupport (6.1.3.2)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -20,7 +20,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
-    codecov (0.5.1)
+    codecov (0.5.2)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
@@ -29,7 +29,7 @@ GEM
     cri (2.15.11)
     deep_merge (1.2.1)
     diff-lcs (1.4.4)
-    docile (1.3.5)
+    docile (1.4.0)
     dotenv (2.7.6)
     hansi (0.2.0)
     hash-deep-merge (0.1.1)
@@ -46,15 +46,13 @@ GEM
       with_env (= 1.1.0)
       xml-simple
     method_source (1.0.0)
-    mini_portile2 (2.5.3)
     minitest (5.14.4)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     mustermann-contrib (1.1.1)
       hansi (~> 0.2.0)
       mustermann (= 1.1.1)
-    nokogiri (1.11.7)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
     oas_parser (0.25.4)
       activesupport (>= 4.0.0)
@@ -65,7 +63,7 @@ GEM
       mustermann-contrib (~> 1.1.1)
       nokogiri
     parslet (1.8.2)
-    pry (0.13.1)
+    pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
@@ -81,10 +79,10 @@ GEM
     rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.1)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.1)
+    rspec-support (3.10.2)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
     simplecov (0.21.2)
@@ -92,13 +90,13 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.2)
-    thor (1.0.1)
+    simplecov_json_formatter (0.1.3)
+    thor (1.1.0)
     toml (0.2.0)
       parslet (~> 1.8.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    webmock (3.11.1)
+    webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -107,7 +105,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   3scale_toolbox!
@@ -122,4 +120,4 @@ DEPENDENCIES
   webmock (~> 3.4)
 
 BUNDLED WITH
-   2.1.4
+   2.2.21


### PR DESCRIPTION
Fix for CVE-2020-36327 rubygem-bundler: Dependencies of gems with explicit source may be installed from a different source

https://issues.redhat.com/browse/THREESCALE-7085