### PR TITLE
update base image to  publicly available unauthenticated registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ruby-27
+FROM registry.access.redhat.com/ubi8/ruby-27
 MAINTAINER Eguzki Astiz Lezaun <eastizle@redhat.com>
 
 USER root


### PR DESCRIPTION
`registry.access.redhat.com` is deprecated and new images are not shipped, exept for a select group, namely the ubi images. 

It is unauthenticated and easier to manage internal builds. 