### PR TITLE
detect OAS format error

### DIFF
--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -108,6 +108,8 @@ module ThreeScaleToolbox
           end
 
           def openapi_parser
+            raise ThreeScaleToolbox::Error, 'only JSON/YAML format is supported' unless openapi_resource.is_a?(Hash)
+
             if openapi_resource.key?('openapi')
               ThreeScaleToolbox::OpenAPI::OAS3.build(openapi_path, openapi_resource, validate: validate)
             else

--- a/spec/unit/commands/import_command/openapi_spec.rb
+++ b/spec/unit/commands/import_command/openapi_spec.rb
@@ -57,4 +57,26 @@ RSpec.describe ThreeScaleToolbox::Commands::ImportCommand::OpenAPI::OpenAPISubco
       end
     end
   end
+
+  context 'invalid html openapi content' do
+    let(:oas_content) do
+      <<~EOF
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <h1>My First Heading</h1>
+            <p>My first paragraph.</p>
+          </body>
+        </html>
+      EOF
+    end
+    let(:oas_resource) { tmp_dir.join('invalid.yaml').tap { |conf| conf.write(oas_content) } }
+
+    context '#run' do
+      it 'raises error' do
+        expect { subject.run }.to raise_error(ThreeScaleToolbox::Error,
+                                              /only JSON\/YAML format is supported/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The '`3scale import openapi` command did not check parsed format when `YAML.safe_load` returned a `string` (which is a valid yaml doc, but not for OAS docs)

```bash
3scale import openapi -d supertest - <<EOF
>  <!DOCTYPE html>
> <html>
> <body>
> 
> <h1>My First Heading</h1>
> <p>My first paragraph.</p>
> 
> </body>
> </html> 
> EOF
{
  "code": "E_UNKNOWN",
  "message": "undefined method `key?' for #<String:0x000055bb120097b8>",
  "class": "NoMethodError",
  "stacktrace": [
    "/home/eguzki/git/3scale_toolbox/lib/3scale_toolbox/commands/import_command/openapi.rb:111:in `openapi_parser'",
    "/home/eguzki/git/3scale_toolbox/lib/3scale_toolbox/commands/import_command/openapi.rb:78:in `create_context'",
    "/home/eguzki/git/3scale_toolbox/lib/3scale_toolbox/commands/import_command/openapi.rb:72:in `context'",
    "/home/eguzki/git/3scale_toolbox/lib/3scale_toolbox/commands/import_command/openapi.rb:52:in `run'",
    "/home/eguzki/git/3scale_toolbox/vendor/bundle/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command_runner.rb:34:in `call'",
    "/home/eguzki/git/3scale_toolbox/vendor/bundle/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command_dsl.rb:294:in `block in runner'",
    "/home/eguzki/git/3scale_toolbox/vendor/bundle/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command.rb:362:in `run_this'",
    "/home/eguzki/git/3scale_toolbox/vendor/bundle/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command.rb:298:in `run'",
    "/home/eguzki/git/3scale_toolbox/vendor/bundle/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command.rb:316:in `run'",
    "/home/eguzki/git/3scale_toolbox/vendor/bundle/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command.rb:316:in `run'",
    "/home/eguzki/git/3scale_toolbox/lib/3scale_toolbox/cli.rb:47:in `block in run'",
    "/home/eguzki/git/3scale_toolbox/lib/3scale_toolbox/cli/error_handler.rb:5:in `block in error_watchdog'",
    "/home/eguzki/git/3scale_toolbox/lib/3scale_toolbox/cli/error_handler.rb:11:in `error_watchdog'",
    "/home/eguzki/git/3scale_toolbox/lib/3scale_toolbox/cli/error_handler.rb:5:in `error_watchdog'",
    "/home/eguzki/git/3scale_toolbox/lib/3scale_toolbox/cli.rb:44:in `run'",
    "/home/eguzki/git/3scale_toolbox/exe/3scale:15:in `<top (required)>'",
    "/home/eguzki/git/3scale_toolbox/vendor/bundle/ruby/2.7.0/bin/3scale:23:in `load'",
    "/home/eguzki/git/3scale_toolbox/vendor/bundle/ruby/2.7.0/bin/3scale:23:in `<main>'"
  ]
}
```

With the fix, the error is meaninful

```bash
3scale import openapi -d supertest - <<EOF
<!DOCTYPE html>
<html>
EOF
{
  "code": "E_3SCALE",
  "message": "only JSON/YAML format is supported",
  "class": "ThreeScaleToolbox::Error"
}
```

This use case is when OAS passed as URL is not a real OAS but some HTML or something else.