### PR TITLE
Setup keep alive connections

### DIFF
--- a/3scale_toolbox.gemspec
+++ b/3scale_toolbox.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.4'
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_dependency '3scale-api', '~> 1.4'
+  spec.add_dependency '3scale-api', '~> 1.6'
   spec.add_dependency 'cri', '~> 2.15'
   spec.add_dependency 'json-schema', '~> 2.8'
   spec.add_dependency 'oas_parser', '~> 0.20'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     3scale_toolbox (0.19.3)
-      3scale-api (~> 1.4)
+      3scale-api (~> 1.6)
       cri (~> 2.15)
       json-schema (~> 2.8)
       oas_parser (~> 0.20)
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    3scale-api (1.4.0)
+    3scale-api (1.6.0)
     activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ COMMANDS
     import               import super command
     method               method super command
     metric               metric super command
+    policies             policies super command
     policy-registry      policy-registry super command
     product              product super command
     proxy-config         proxy-config super command
@@ -92,6 +93,7 @@ COMMANDS
 OPTIONS
     -c --config-file=<value>      3scale toolbox configuration file (default:
                                   $HOME/.3scalerc.yaml)
+       --disable-keep-alive       Disable keep alive HTTP connection mode
     -h --help                     show help for this command
     -k --insecure                 Proceed and operate even for server
                                   connections otherwise considered insecure

--- a/docs/activedocs.md
+++ b/docs/activedocs.md
@@ -42,17 +42,6 @@ OPTIONS
                                        ActiveDocs
        --skip-swagger-validations      Specify it to skip validation of the
                                        Swagger specification
-
-OPTIONS FOR ACTIVEDOCS
-    -c --config-file=<value>           3scale toolbox configuration file
-                                       (default:
-                                       $HOME/.3scalerc.yaml)
-    -h --help                          show help for this command
-    -k --insecure                      Proceed and operate even for server
-                                       connections otherwise considered
-                                       insecure
-    -v --version                       Prints the version of this command
-       --verbose                       Verbose mode
 ```
 
 
@@ -102,17 +91,6 @@ OPTIONS
                                                ActiveDocs
        --skip-swagger-validations=<value>      Skip validation of the Swagger
                                                specification. true or false
-
-OPTIONS FOR ACTIVEDOCS
-    -c --config-file=<value>           3scale toolbox configuration file
-                                       (default:
-                                       $HOME/.3scalerc.yaml)
-    -h --help                          show help for this command
-    -k --insecure                      Proceed and operate even for server
-                                       connections otherwise considered
-                                       insecure
-    -v --version                       Prints the version of this command
-       --verbose                       Verbose mode
 ```
 
 ### List
@@ -130,15 +108,6 @@ DESCRIPTION
 OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
     -s --service-ref=<value>      Filter the ActiveDocs by Service reference
-
-OPTIONS FOR ACTIVEDOCS
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Delete
@@ -153,13 +122,4 @@ USAGE
 
 DESCRIPTION
     Remove an ActiveDocs
-
-OPTIONS FOR ACTIVEDOCS
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```

--- a/docs/app-plan.md
+++ b/docs/app-plan.md
@@ -40,17 +40,6 @@ OPTIONS
        --setup-fee=<value>              Setup fee
     -t --system-name=<value>            Application plan system name
        --trial-period-days=<value>      Trial period days
-
-OPTIONS FOR APPLICATION-PLAN
-    -c --config-file=<value>            3scale toolbox configuration file
-                                        (default:
-                                        $HOME/.3scalerc.yaml)
-    -h --help                           show help for this command
-    -k --insecure                       Proceed and operate even for server
-                                        connections otherwise considered
-                                        insecure
-    -v --version                        Prints the version of this command
-       --verbose                        Verbose mode
 ```
 
 ### Apply
@@ -91,17 +80,6 @@ OPTIONS
     -p --publish                        Publish application plan
        --setup-fee=<value>              Setup fee
        --trial-period-days=<value>      Trial period days
-
-OPTIONS FOR APPLICATION-PLAN
-    -c --config-file=<value>            3scale toolbox configuration file
-                                        (default:
-                                        $HOME/.3scalerc.yaml)
-    -h --help                           show help for this command
-    -k --insecure                       Proceed and operate even for server
-                                        connections otherwise considered
-                                        insecure
-    -v --version                        Prints the version of this command
-       --verbose                        Verbose mode
 ```
 
 ### List
@@ -119,15 +97,6 @@ DESCRIPTION
 
 OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
-
-OPTIONS FOR APPLICATION-PLAN
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Delete
@@ -142,15 +111,6 @@ USAGE
 
 DESCRIPTION
     Delete application plan
-
-OPTIONS FOR APPLICATION-PLAN
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Show
@@ -169,13 +129,4 @@ DESCRIPTION
 
 OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
-
-OPTIONS FOR APPLICATION-PLAN
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -24,15 +24,6 @@ OPTIONS
        --plan=<value>             Filter by application plan. Service option
                                   required
        --service=<value>          Filter by service
-
-OPTIONS FOR APPLICATION
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Create
@@ -72,15 +63,6 @@ OPTIONS
        --redirect-url=<value>         OpenID Connect redirect url
        --user-key=<value>             User Key (API Key) of the application
                                       to be created.
-
-OPTIONS FOR APPLICATION
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Show
@@ -107,15 +89,6 @@ DESCRIPTION
 
 OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
-
-OPTIONS FOR APPLICATION
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Apply
@@ -176,15 +149,6 @@ OPTIONS
                                       state to suspended)
        --user-key=<value>             User Key (API Key) of the application
                                       to be created.
-
-OPTIONS FOR APPLICATION
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Delete

--- a/docs/copy-policy-registry.md
+++ b/docs/copy-policy-registry.md
@@ -19,13 +19,4 @@ USAGE
 
 DESCRIPTION
     Copy policy registry
-
-OPTIONS FOR POLICY-REGISTRY
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```

--- a/docs/export-import-app-plan.md
+++ b/docs/export-import-app-plan.md
@@ -35,15 +35,6 @@ DESCRIPTION
 
 OPTIONS
     -f --file=<value>             Write to file instead of stdout
-
-OPTIONS FOR APPLICATION-PLAN
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Import Application Plan Usage
@@ -62,16 +53,6 @@ DESCRIPTION
 OPTIONS
     -f --file=<value>                  Read from file or url instead of stdin
     -p --plan=<value>                  Override application plan reference
-
-OPTIONS FOR APPLICATION-PLAN
-    -c --config-file=<value>           3scale toolbox configuration file
-                                       (default: $HOME/.3scalerc.yaml)
-    -h --help                          show help for this command
-    -k --insecure                      Proceed and operate even for server
-                                       connections otherwise considered
-                                       insecure
-    -v --version                       Prints the version of this command
-       --verbose                       Verbose mode
 ```
 
 ### Export application plan 'basic' to a file

--- a/docs/method.md
+++ b/docs/method.md
@@ -31,15 +31,6 @@ OPTIONS
                                   plans
     -o --output=<value>           Output format. One of: json|yaml
     -t --system-name=<value>      Method system name
-
-OPTIONS FOR METHOD
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Apply
@@ -71,15 +62,6 @@ OPTIONS
                                   plans
     -n --name=<value>             Method name
     -o --output=<value>           Output format. One of: json|yam
-
-OPTIONS FOR METHOD
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                   $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### List
@@ -96,15 +78,6 @@ DESCRIPTION
 
 OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
-
-OPTIONS FOR METHOD
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Delete
@@ -119,13 +92,4 @@ USAGE
 
 DESCRIPTION
     Delete method
-
-OPTIONS FOR METHOD
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```

--- a/docs/metric.md
+++ b/docs/metric.md
@@ -32,15 +32,6 @@ OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
     -t --system-name=<value>      Metric system name
        --unit=<value>             Metric unit. Default hit
-
-OPTIONS FOR METRIC
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Apply
@@ -73,15 +64,6 @@ OPTIONS
     -n --name=<value>             Metric name
     -o --output=<value>           Output format. One of: json|yaml
        --unit=<value>             Metric unit. Default hit
-
-OPTIONS FOR METRIC
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### List
@@ -98,15 +80,6 @@ DESCRIPTION
 
 OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
-
-OPTIONS FOR METRIC
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Delete
@@ -121,13 +94,4 @@ USAGE
 
 DESCRIPTION
     Delete metric
-
-OPTIONS FOR METRIC
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```

--- a/docs/proxy-config.md
+++ b/docs/proxy-config.md
@@ -21,15 +21,6 @@ DESCRIPTION
 
 OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
-
-OPTIONS FOR PROXY-CONFIG
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Show
@@ -50,16 +41,6 @@ OPTIONS
                                      If not specified it gets the latest
                                      version (default: latest)
     -o --output=<value>              Output format. One of: json|yaml
-
-OPTIONS FOR PROXY-CONFIG
-    -c --config-file=<value>         3scale toolbox configuration file
-                                     (default: $HOME/.3scalerc.yaml)
-    -h --help                        show help for this command
-    -k --insecure                    Proceed and operate even for server
-                                     connections otherwise considered
-                                     insecure
-    -v --version                     Prints the version of this command
-       --verbose                     Verbose mode
 ```
 
 ### Promote
@@ -73,15 +54,6 @@ USAGE
 
 DESCRIPTION
     Promote latest staging Proxy Configuration to the production environment
-
-OPTIONS FOR PROXY-CONFIG
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Export

--- a/docs/service.md
+++ b/docs/service.md
@@ -39,17 +39,6 @@ OPTIONS
                                           service
        --support-email=<value>            Specify the support email of the
                                           service
-
-OPTIONS FOR SERVICE
-    -c --config-file=<value>              3scale toolbox configuration file
-                                          (default:
-                                          $HOME/.3scalerc.yaml)
-    -h --help                             show help for this command
-    -k --insecure                         Proceed and operate even for server
-                                          connections otherwise considered
-                                          insecure
-    -v --version                          Prints the version of this command
-       --verbose                          Verbose mode
 ```
 
 ### Apply
@@ -83,17 +72,6 @@ OPTIONS
     -o --output=<value>                   Output format. One of: json|yaml
        --support-email=<value>            Specify the support email of the
                                           service
-
-OPTIONS FOR SERVICE
-    -c --config-file=<value>              3scale toolbox configuration file
-                                          (default:
-                                          $HOME/.3scalerc.yaml)
-    -h --help                             show help for this command
-    -k --insecure                         Proceed and operate even for server
-                                          connections otherwise considered
-                                          insecure
-    -v --version                          Prints the version of this command
-       --verbose                          Verbose mode
 ```
 
 ### List
@@ -110,15 +88,6 @@ DESCRIPTION
 
 OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
-
-OPTIONS FOR SERVICE
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 ### Show
@@ -135,15 +104,6 @@ DESCRIPTION
 
 OPTIONS
     -o --output=<value>           Output format. One of: json|yaml
-
-OPTIONS FOR SERVICE
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```
 
 
@@ -159,13 +119,4 @@ USAGE
 
 DESCRIPTION
     Delete a service
-
-OPTIONS FOR SERVICE
-    -c --config-file=<value>      3scale toolbox configuration file (default:
-                                  $HOME/.3scalerc.yaml)
-    -h --help                     show help for this command
-    -k --insecure                 Proceed and operate even for server
-                                  connections otherwise considered insecure
-    -v --version                  Prints the version of this command
-       --verbose                  Verbose mode
 ```

--- a/lib/3scale_toolbox/3scale_client_factory.rb
+++ b/lib/3scale_toolbox/3scale_client_factory.rb
@@ -1,18 +1,19 @@
 module ThreeScaleToolbox
   class ThreeScaleClientFactory
     class << self
-      def get(remotes, remote_str, verify_ssl, verbose = false)
-        new(remotes, remote_str, verify_ssl, verbose).call
+      def get(remotes, remote_str, verify_ssl, verbose = false, keep_alive = true)
+        new(remotes, remote_str, verify_ssl, verbose, keep_alive).call
       end
     end
 
-    attr_reader :remotes, :remote_str, :verify_ssl, :verbose
+    attr_reader :remotes, :remote_str, :verify_ssl, :verbose, :keep_alive
 
-    def initialize(remotes, remote_str, verify_ssl, verbose)
+    def initialize(remotes, remote_str, verify_ssl, verbose, keep_alive)
       @remotes = remotes
       @remote_str = remote_str
       @verify_ssl = verify_ssl
       @verbose = verbose
+      @keep_alive = keep_alive
     end
 
     def call
@@ -22,15 +23,16 @@ module ThreeScaleToolbox
         remote = remotes.fetch(remote_str)
       end
 
-      client = remote_client(**remote.merge(verify_ssl: verify_ssl))
+      client = remote_client(**remote.merge(verify_ssl: verify_ssl, keep_alive: keep_alive))
       client = ProxyLogger.new(client) if verbose
       RemoteCache.new(client)
     end
 
     private
 
-    def remote_client(endpoint:, authentication:, verify_ssl:)
-      ThreeScale::API.new(endpoint: endpoint, provider_key: authentication, verify_ssl: verify_ssl)
+    def remote_client(endpoint:, authentication:, verify_ssl:, keep_alive:)
+      ThreeScale::API.new(endpoint: endpoint, provider_key: authentication,
+                          verify_ssl: verify_ssl, keep_alive: keep_alive)
     end
   end
 end

--- a/lib/3scale_toolbox/base_command.rb
+++ b/lib/3scale_toolbox/base_command.rb
@@ -46,7 +46,7 @@ module ThreeScaleToolbox
     # Input param can be endpoint url or remote name
     #
     def threescale_client(str)
-      ThreeScaleClientFactory.get(remotes, str, verify_ssl, verbose)
+      ThreeScaleClientFactory.get(remotes, str, verify_ssl, verbose, keep_alive)
     end
 
     def verify_ssl
@@ -56,6 +56,10 @@ module ThreeScaleToolbox
 
     def verbose
       options[:verbose]
+    end
+
+    def keep_alive
+      !options[:'disable-keep-alive']
     end
 
     def exit_with_message(message)

--- a/lib/3scale_toolbox/commands/3scale_command.rb
+++ b/lib/3scale_toolbox/commands/3scale_command.rb
@@ -17,6 +17,7 @@ module ThreeScaleToolbox
           end
           flag :k, :insecure, 'Proceed and operate even for server connections otherwise considered insecure'
           flag nil, :verbose, 'Verbose mode'
+          flag nil, :'disable-keep-alive', 'Disable keep alive HTTP connection mode'
           flag :h, :help, 'show help for this command' do |_, cmd|
             puts cmd.help
             exit 0


### PR DESCRIPTION
Currently, each 3scale admin API call required to setup a new TCP/HTTP connection. For 3scale commands running multiple 3scale API calls, the toolbox spends a lot of time on TCP/HTTP connection setup. Specially true for TLS connections.

With this change, by default, the connection opened by the 3scale toolbox command (if the command requires opening a connection) will be setup to keep alive. Thus, all API calls required for the command will reuse the connection.

If, for whatever reason, the `Connection: close` behavior is desired, the PR includes a new top level option parameter:

```
--disable-keep-alive       Disable keep alive HTTP connection mode
```

