### PR TITLE
Support StringIO object as format of ResourceReader

### DIFF
--- a/lib/3scale_toolbox/resource_reader.rb
+++ b/lib/3scale_toolbox/resource_reader.rb
@@ -21,6 +21,8 @@ module ThreeScaleToolbox
         method(:read_stdin)
       when /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
         method(:read_url)
+      when StringIO
+        method(:read_stringio)
       else
         method(:read_file)
       end.call(resource)
@@ -40,6 +42,10 @@ module ThreeScaleToolbox
 
     def read_url(resource)
       Net::HTTP.get(URI.parse(resource))
+    end
+
+    def read_stringio(resource)
+      resource.string
     end
   end
 end

--- a/spec/unit/resource_reader_spec.rb
+++ b/spec/unit/resource_reader_spec.rb
@@ -114,5 +114,10 @@ RSpec.describe ThreeScaleToolbox::ResourceReader do
 
       it_behaves_like 'content is read'
     end
+
+    context 'from stringio' do
+      let(:resource) { StringIO.new content }
+      it_behaves_like 'content is read'
+    end
   end
 end


### PR DESCRIPTION
Minor improvement to support passing `stringio` for convenience,  
This is mainly because I have a use case to read resources in a plugin, before invocation of `ResourceReader` module and no need to do the read operation twice.

Specs added and passing:
```bash
$ rspec spec/unit/resource_reader_spec.rb
Randomized with seed 29683

  ThreeScaleToolbox::ResourceReader
    #load_resource
      invalid json
        raises error
      valid json
        does not return nil
        is loaded
      valid yaml
        does not return nil
        is loaded
      invalid yaml
        raises error
    #read_content
      from URL
        behaves like content is read
          does not return nil
          is read
      from stdin
        behaves like content is read
          is read
          does not return nil
      from stringio
        behaves like content is read
          does not return nil
          is read
      from folder
        error is raised
      from file
        behaves like content is read
          is read
          does not return nil


Finished in 0.05864 seconds (files took 1.67 seconds to load)
15 examples, 0 failures

Randomized with seed 29683
Coverage report generated for RSpec to ./code/3scale/3scale_toolbox/coverage. 2771 / 6581 LOC (42.11%) covered.
```

@eguzki @abdennour for your kind review.