### PR TITLE
Fix CI docker image test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2.1
 
 ##################################### YAML ANCHORS  ############################################
@@ -119,7 +120,7 @@ jobs:
       - setup-docker
       - run:
           name: Docker container help test
-          shell: /bin/bash
+          shell: /bin/sh
           command: |
             docker rmi quay.io/redhat/3scale-toolbox:main || true
             docker run --rm -t quay.io/redhat/3scale-toolbox:main 3scale help
@@ -186,8 +187,8 @@ workflows:
 
   integration:
     jobs:
-      - manual_approval: # <<< A job that will require manual approval in the CircleCI web application.
-          type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
+      - manual_approval:  # <<< A job that will require manual approval in the web application.
+          type: approval  # <<< This key-value pair will set your workflow to a status of "On Hold"
           # On approval of the `hold` job, any successive job that requires the `hold` job will run.
       - integration_tests:
           context: autotestaccount


### PR DESCRIPTION
CircleCI `docker:stable` image does not have `bin/bash`