### PR TITLE
verify_ssl option on resource_reader by URL

### DIFF
--- a/lib/3scale_toolbox/commands/activedocs_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/activedocs_command/apply_command.rb
@@ -108,7 +108,7 @@ module ThreeScaleToolbox
 
           def read_activedocs_json_spec
             activedoc_spec = option_openapi_spec
-            activedoc_spec_content = load_resource(activedoc_spec)
+            activedoc_spec_content = load_resource(activedoc_spec, verify_ssl)
             JSON.pretty_generate(activedoc_spec_content)
           end
 

--- a/lib/3scale_toolbox/commands/activedocs_command/create_command.rb
+++ b/lib/3scale_toolbox/commands/activedocs_command/create_command.rb
@@ -52,20 +52,19 @@ module ThreeScaleToolbox
           end
 
           def activedocs_json_spec
-            activedoc_spec = arguments[:activedocs_spec]
-            activedoc_spec_content = load_resource(arguments[:activedocs_spec])
+            activedoc_spec_content = load_resource(arguments[:activedocs_spec], verify_ssl)
             JSON.pretty_generate(activedoc_spec_content)
           end
 
           def activedocs_attrs
             {
-              "service_id" => options[:'service-id'],
-              "published" => options[:'published'],
-              "skip_swagger_validations" => options[:'skip-swagger-validations'],
-              "description" => options[:'description'],
-              "system_name" => options[:'system-name'],
-              "name" => activedocs_name,
-              "body" => activedocs_json_spec,
+              'service_id' => options[:'service-id'],
+              'published' => options[:'published'],
+              'skip_swagger_validations' => options[:'skip-swagger-validations'],
+              'description' => options[:'description'],
+              'system_name' => options[:'system-name'],
+              'name' => activedocs_name,
+              'body' => activedocs_json_spec,
             }.compact
           end
 

--- a/lib/3scale_toolbox/commands/import_command/openapi.rb
+++ b/lib/3scale_toolbox/commands/import_command/openapi.rb
@@ -95,7 +95,7 @@ module ThreeScaleToolbox
           end
 
           def openapi_resource
-            @openapi_resource ||= load_resource(openapi_path)
+            @openapi_resource ||= load_resource(openapi_path, verify_ssl)
           end
 
           def openapi_path

--- a/lib/3scale_toolbox/commands/plans_command/import_command.rb
+++ b/lib/3scale_toolbox/commands/plans_command/import_command.rb
@@ -53,7 +53,7 @@ module ThreeScaleToolbox
 
           def create_context
             {
-              artifacts_resource: load_resource(options[:file] || '-'),
+              artifacts_resource: load_resource(options[:file] || '-', verify_ssl),
               threescale_client: threescale_client(arguments[:remote]),
               service_system_name: arguments[:service_system_name],
               plan_system_name: options[:plan],

--- a/lib/3scale_toolbox/commands/policies_command/import_command.rb
+++ b/lib/3scale_toolbox/commands/policies_command/import_command.rb
@@ -53,7 +53,7 @@ module ThreeScaleToolbox
         end
 
         def policies
-          @policies ||= load_resource(options[:file] || options[:url] || '-')
+          @policies ||= load_resource(options[:file] || options[:url] || '-', verify_ssl)
         end
       end
     end

--- a/lib/3scale_toolbox/commands/product_command/import_command.rb
+++ b/lib/3scale_toolbox/commands/product_command/import_command.rb
@@ -106,7 +106,7 @@ module ThreeScaleToolbox
         end
 
         def artifacts_resource
-          @artifacts_resource ||= load_resource(options[:file] || '-')
+          @artifacts_resource ||= load_resource(options[:file] || '-', verify_ssl)
         end
 
         def report


### PR DESCRIPTION
The flag to skip TLS verification was available for HTTP connections against 3scale API. This PR adds the option to skip TLS verification for HTTP connections used to read external resources. Used for commands like`3scale import openapi` where the OAS doc is hosted in some URL.

https://issues.redhat.com/browse/THREESCALE-7850