### PR TITLE
ruby as the only platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,8 +57,6 @@ GEM
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-linux)
-      racc (~> 1.4)
     oas_parser (0.25.4)
       activesupport (>= 4.0.0)
       addressable (~> 2.3)
@@ -111,9 +109,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
-  powerpc64le-linux
-  s390x-linux
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   3scale_toolbox!


### PR DESCRIPTION
commands run to update
```
bundle lock --add-platform ruby
bundle lock --remove-platform powerpc64le-linux
bundle lock --remove-platform s390x-linux
bundle lock --remove-platform x86_64-linux
```