### PR TITLE
THREESCALE-8707 Fix apply app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+-  Apply application command: only set app key type depending on backend_version [#361](https://github.com/3scale/3scale_toolbox/pull/361)
+
+### Changed
+- Upgrade internal dependencies [#351](https://github.com/3scale/3scale_toolbox/pull/351) [#353](https://github.com/3scale/3scale_toolbox/pull/353) [#354](https://github.com/3scale/3scale_toolbox/pull/354) [#359](https://github.com/3scale/3scale_toolbox/pull/359) [#360](https://github.com/3scale/3scale_toolbox/pull/360)
+
 ## [0.20.0]
 
 ### Added

--- a/lib/3scale_toolbox/commands/application_command/apply_command.rb
+++ b/lib/3scale_toolbox/commands/application_command/apply_command.rb
@@ -102,8 +102,8 @@ module ThreeScaleToolbox
             {
               'name' => option_name,
               'description' => description,
-              'user_key' => application_ref,
-              'application_id' => application_ref,
+              'user_key' => user_key,
+              'application_id' => application_id,
               'application_key' => option_app_key,
               'redirect_url' => option_redirect_url,
             }.compact
@@ -118,6 +118,14 @@ module ThreeScaleToolbox
               'user_key' => option_user_key,
               'redirect_url' => option_redirect_url,
             }.compact
+          end
+
+          def user_key
+            application_ref if service.backend_version == '1'
+          end
+
+          def application_id
+            application_ref if service.backend_version == '2' || service.backend_version == 'oidc'
           end
 
           def account

--- a/spec/unit/commands/application_command/apply_command_spec.rb
+++ b/spec/unit/commands/application_command/apply_command_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ApplicationCommand::Apply::ApplySubc
   let(:options) { {} }
   let(:service_class) { class_double(ThreeScaleToolbox::Entities::Service).as_stubbed_const }
   let(:service_id) { 100 }
+  let(:backend_version) { '1' }
   let(:account_id) { 200 }
   let(:service) { instance_double(ThreeScaleToolbox::Entities::Service) }
   let(:account_class) { class_double(ThreeScaleToolbox::Entities::Account).as_stubbed_const }
@@ -19,6 +20,7 @@ RSpec.describe ThreeScaleToolbox::Commands::ApplicationCommand::Apply::ApplySubc
 
   before :example do
     allow(service).to receive(:id).and_return(service_id)
+    allow(service).to receive(:backend_version).and_return(backend_version)
     allow(account).to receive(:id).and_return(account_id)
     allow(application).to receive(:attrs).and_return(app_attrs)
   end
@@ -319,14 +321,18 @@ RSpec.describe ThreeScaleToolbox::Commands::ApplicationCommand::Apply::ApplySubc
           expect { subject.run }.to output(/Applied application id: 1/).to_stdout
         end
 
-        it 'application_id set to application param' do
-          expect(application_class).to receive(:create)
-            .with(
-              remote: remote, account_id: account_id,
-              plan_id: 'planId', app_attrs: hash_including('application_id' => app_ref)
-            )
-            .and_return(application)
-          expect { subject.run }.to output(/Applied application id: 1/).to_stdout
+        context 'app_id&app_key type service' do
+          let(:backend_version) { '2' }
+
+          it 'application_id set to application param' do
+            expect(application_class).to receive(:create)
+              .with(
+                remote: remote, account_id: account_id,
+                plan_id: 'planId', app_attrs: hash_including('application_id' => app_ref)
+              )
+              .and_return(application)
+            expect { subject.run }.to output(/Applied application id: 1/).to_stdout
+          end
         end
 
         it 'description is included' do


### PR DESCRIPTION
### what 

Jira: https://issues.redhat.com/browse/THREESCALE-8707

The source issue was that applications were created populating both `user_key` and `application_id` regardless of the product's authentication mode (`backend_version` attr). When the auth mode is `user_key` (`backend_version` attr equals `'1'`), the `application_id` was also populated. After user key regeneration, the user_key changed but not the `application_id`. When the toolbox asked for an application with user_key `application_parameter10`,3scale returned not found as expected. Then the toolbox asked for an application with application _id `application_parameter10` which existed, but since the auth mode is `user_key` 3scale still returned not found. In the last step, when the toolbox tried to create a new app with application_id `application_parameter10`, 3scale complained saying it is already used and the command failed. This is because the regenerated application, somehow (internal stuff), still kept application_id as `application_parameter10`, hence failing the creation step. 

The fix consists on populating only required fields. No more.

### verification steps

* Create a new application with command "application apply"
```
3scale --verbose application apply --account=<value> --service=<value> --description=<value> --name=<value> --plan=<value> <remote> application_parameter10
```
* Retrieve the application attributes. It must return recently created app
```
3scale --verbose application show <remote> application_parameter10
```
* Regenerate the User Key through the Admin Portal UI and check the attributes again, so the application user_key has anew value and not `application_parameter10` as defined in the first step:
```
3scale --verbose application show <remote> application_parameter10
```
The following error should be returned:

```yaml
{
  "code": "E_3SCALE",
  "message": "Application application_parameter10 does not exist",
  "class": "ThreeScaleToolbox::Error"
}
```
* try to rerun the command mentioned in the first step, i.e. create a new application with the `application_parameter10` user key
```
3scale --verbose application apply --account=<value> --service=<value> --description=<value> --name=<value> --plan=<value> <remote> application_parameter10
```
This command should not fail and you should end up having two applicatins with the same name and descriptions, but different user key.



