### PR TITLE
remove nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,12 +185,3 @@ workflows:
           context: autotestaccount
           requires:
             - manual_approval
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          <<: *only-main-filter
-    jobs:
-      - integration_tests:
-          context: autotestaccount
-      - docker_container_help_test


### PR DESCRIPTION
When `main` head does not change, codecoverage reports eventually will fail for too many code coverage reports on the same git revision. That will fail the whole build. 

To be restored back when the toolbox gets more love